### PR TITLE
Update the opentelemetry SDK to 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emit_opentelemetry"
-version = "0.26.1"
+version = "0.27.0"
 authors = ["emit contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -21,11 +21,11 @@ features = ["std", "serde", "implicit_internal_rt"]
 default-features = false
 
 [dependencies.opentelemetry_sdk]
-version = "0.26"
+version = "0.27"
 features = ["logs", "trace"]
 
 [dependencies.opentelemetry]
-version = "0.26"
+version = "0.27"
 features = ["logs", "trace"]
 
 [dependencies.serde]
@@ -36,9 +36,9 @@ version = "0.11"
 features = ["implicit_rt"]
 
 [dev-dependencies.opentelemetry_sdk]
-version = "0.26"
+version = "0.27"
 features = ["logs", "trace", "testing"]
 
 [dev-dependencies.opentelemetry-stdout]
-version = "0.26"
+version = "0.27"
 features = ["logs", "trace"]

--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 
 [![opentelemetry](https://github.com/emit-rs/emit_opentelemetry/actions/workflows/opentelemetry.yml/badge.svg)](https://github.com/emit-rs/emit_opentelemetry/actions/workflows/opentelemetry.yml)
 
-[Current docs](https://docs.rs/emit_opentelemetry/0.26.1/emit_opentelemetry/index.html)
+[Current docs](https://docs.rs/emit_opentelemetry/0.27.0/emit_opentelemetry/index.html)
 
 Integrate `emit` with the OpenTelemetry SDK.
 
 This library forwards diagnostic events from emit through the OpenTelemetry SDK as log records and spans.
+
+## Versioning and compatibility
+
+`emit_opentelemetry` version `x.y.z` is compatible with `opentelemetry_sdk` version `x.y.*`.

--- a/examples/getting_started/Cargo.toml
+++ b/examples/getting_started/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emit_example_opentelemetry_getting_started"
-version = "0.26.1"
+version = "0.27.0"
 authors = ["emit contributors"]
 edition = "2021"
 publish = false
@@ -12,15 +12,15 @@ version = "0.11"
 path = "../../"
 
 [dependencies.opentelemetry_sdk]
-version = "0.26"
+version = "0.27"
 features = ["rt-tokio", "trace", "logs"]
 
 [dependencies.opentelemetry]
-version = "0.26"
+version = "0.27"
 features = ["trace", "logs"]
 
 [dependencies.opentelemetry-otlp]
-version = "0.26"
+version = "0.27"
 features = ["trace", "logs", "grpc-tonic", "gzip-tonic"]
 
 [dependencies.tonic]


### PR DESCRIPTION
Most of the changes here are to `opentelemetry_otlp`, which is just part of our example.