### PR TITLE
Update to the 0.31 release of opentelemetry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ features = ["std", "serde", "implicit_internal_rt"]
 default-features = false
 
 [dependencies.opentelemetry_sdk]
-version = "0.30"
+version = "0.31"
 features = ["logs", "trace"]
 
 [dependencies.opentelemetry]
-version = "0.30"
+version = "0.31"
 features = ["logs", "trace"]
 
 [dependencies.serde]
@@ -36,11 +36,11 @@ version = "1.8"
 features = ["implicit_rt"]
 
 [dev-dependencies.opentelemetry_sdk]
-version = "0.30"
+version = "0.31"
 features = ["logs", "trace", "testing"]
 
 [dev-dependencies.opentelemetry-stdout]
-version = "0.30"
+version = "0.31"
 features = ["logs", "trace"]
 
 [dev-dependencies.serde]

--- a/examples/getting_started/Cargo.toml
+++ b/examples/getting_started/Cargo.toml
@@ -12,19 +12,19 @@ version = "1"
 path = "../../"
 
 [dependencies.opentelemetry_sdk]
-version = "0.30"
+version = "0.31"
 features = ["rt-tokio", "trace", "logs"]
 
 [dependencies.opentelemetry]
-version = "0.30"
+version = "0.31"
 features = ["trace", "logs"]
 
 [dependencies.opentelemetry-otlp]
-version = "0.30"
+version = "0.31"
 features = ["trace", "logs", "grpc-tonic", "gzip-tonic"]
 
 [dependencies.tonic]
-version = "0.13"
+version = "0.14"
 
 [dependencies.tokio]
 version = "1"

--- a/examples/getting_started/src/main.rs
+++ b/examples/getting_started/src/main.rs
@@ -59,14 +59,14 @@ fn run_emit() {
     emit::info!("Counted up to {counter}");
 
     // Emit a metric sample
-    emit::runtime::shared().emit(emit::Metric::new(
-        emit::mdl!(),
-        "counter",
-        emit::well_known::METRIC_AGG_COUNT,
-        emit::Empty,
-        counter,
-        emit::Empty,
-    ));
+    //
+    // NOTE: This sample will be emitted as a log, not a metric.
+    // To send `emit`'s metrics via the OpenTelemetry SDK, you'll
+    // need to use `emit_otlp` instead.
+    //
+    // You can still use `emit` for logs and traces, and just use the
+    // OpenTelemetry SDK for your metrics.
+    emit::count_sample!(value: counter);
 }
 
 fn run_opentelemetry<T: opentelemetry::trace::TracerProvider>(tracer_provider: T)


### PR DESCRIPTION
This PR just updates the OpenTelemetry SDK version we target to the latest `0.31.0` release.