### PR TITLE
Add an example of integrating multiple frameworks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 [workspace]
 members = [
     "examples/getting_started",
+    "examples/multi_framework",
 ]
 
 [dependencies.emit]

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 Integrate [`emit`](https://github.com/emit-rs/emit) with the OpenTelemetry SDK.
 
 This library forwards diagnostic events from emit through the OpenTelemetry SDK as log records and spans.
-It lets you use `emit`'s ergonomic developer-oriented APIs in your OpenTelemetry-instrumented applications.
-See [the guide](https://emit-rs.io) for more details on using `emit`.
+It lets you use `emit`'s ergonomic developer-oriented API in your OpenTelemetry-instrumented applications.
+It's also ideal for applications integrating multiple frameworks together, using the OpenTelemetry SDK as a common target.
+
+See [the guide](https://emit-rs.io) for more details on using `emit` itself.
 
 ## Getting started
 
@@ -52,11 +54,35 @@ fn main() {
 
     rt.blocking_flush(std::time::Duration::from_secs(30));
 
-    // Shutdown the OpenTelemetry SDK
+    // Shutdown the SDK
+    let _ = logger_provider.shutdown();
+    let _ = tracer_provider.shutdown();
 }
 ```
 
 This function accepts a [`LoggerProvider`](https://docs.rs/opentelemetry/0.28/opentelemetry/logs/trait.LoggerProvider.html) and [`TracerProvider`](https://docs.rs/opentelemetry/0.28/opentelemetry/trace/trait.TracerProvider.html) from the OpenTelemetry SDK to forward `emit` events to.
+
+## Logging
+
+Events emitted with `emit` will be mapped into OpenTelemetry log records:
+
+```rust
+let user = "Rust";
+
+// This event will be emitted to the OpenTelemetry `LoggerProvider`
+emit::info!("hello, {user}!");
+```
+
+## Tracing
+
+Functions annotated with `emit` will be mapped into OpenTelemetry spans, with trace context managed by the OpenTelemetry SDK:
+
+```rust
+#[emit::span("instrumented function")]
+fn instrumented_fn() {
+    // Within the body of this function, the OpenTelemetry `Context` will carry the trace context computed by the `#[emit::span]` macro
+}
+```
 
 For more details on how to use `emit` once you've initialized it, see [the guide](https://emit-rs.io), or [examples in the main `emit` repository](https://github.com/emit-rs/emit/tree/main/examples).
 

--- a/examples/getting_started/src/main.rs
+++ b/examples/getting_started/src/main.rs
@@ -4,7 +4,7 @@ This example demonstrates configuring `emit` to forward its events through the O
 This is useful if you're already using the OpenTelemtry SDK, or if your application uses multiple frameworks.
 */
 
-use opentelemetry_otlp::WithTonicConfig;
+use opentelemetry_otlp::WithTonicConfig as _;
 
 #[tokio::main]
 async fn main() {

--- a/examples/multi_framework/Cargo.toml
+++ b/examples/multi_framework/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "multi_framework"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+# emit
+[dependencies.emit]
+version = "1"
+
+[dependencies.emit_opentelemetry]
+path = "../../"
+
+# log
+[dependencies.log]
+version = "0.4"
+
+[dependencies.opentelemetry-appender-log]
+version = "0.31"
+
+# tracing
+[dependencies.tracing]
+version = "0.1"
+
+[dependencies.tracing-subscriber]
+version = "0.3"
+
+[dependencies.tracing-opentelemetry]
+version = "0.32"
+
+# opentelemetry
+[dependencies.opentelemetry_sdk]
+version = "0.31"
+features = ["rt-tokio", "trace", "logs"]
+
+[dependencies.opentelemetry]
+version = "0.31"
+features = ["trace", "logs"]
+
+[dependencies.opentelemetry-otlp]
+version = "0.31"
+features = ["trace", "logs", "grpc-tonic", "gzip-tonic"]
+
+[dependencies.tonic]
+version = "0.14"
+
+# Misc.
+[dependencies.tokio]
+version = "1"
+features = ["rt", "macros", "rt-multi-thread"]

--- a/examples/multi_framework/src/main.rs
+++ b/examples/multi_framework/src/main.rs
@@ -1,0 +1,121 @@
+/*!
+This example demonstrates configuring a few different diagnostic frameworks in the same application, all coordinating via the OpenTelemetry SDK.
+
+In this case we're using:
+
+- `log` and `emit` for logging.
+- `tracing`, `opentelemetry`, and `emit` for tracing.
+
+Large or complex applications may end up needing to integration components with different frameworks.
+The OpenTelemetry SDK presents an ideal target for each of these frameworks to integrate with.
+*/
+
+use std::sync::Arc;
+
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::WithTonicConfig as _;
+use tracing_subscriber::layer::SubscriberExt as _;
+
+#[tokio::main]
+async fn main() {
+    // 1. Configure the OpenTelemetry SDK
+    let channel = tonic::transport::Channel::from_static("http://localhost:4319")
+        .connect()
+        .await
+        .unwrap();
+
+    let trace_exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .with_channel(channel.clone())
+        .build()
+        .unwrap();
+
+    let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_batch_exporter(trace_exporter)
+        .build();
+
+    let log_exporter = opentelemetry_otlp::LogExporter::builder()
+        .with_tonic()
+        .with_channel(channel.clone())
+        .build()
+        .unwrap();
+
+    let logger_provider = opentelemetry_sdk::logs::SdkLoggerProvider::builder()
+        .with_batch_exporter(log_exporter)
+        .build();
+
+    // 2. Configure `emit` to point to `opentelemetry`
+    let _ = emit_opentelemetry::setup(logger_provider.clone(), tracer_provider.clone()).init();
+
+    // 3. Configure `log` to point to `opentelemetry`
+    log::set_boxed_logger(Box::new(
+        opentelemetry_appender_log::OpenTelemetryLogBridge::new(&logger_provider),
+    ))
+    .unwrap();
+    log::set_max_level(log::LevelFilter::max());
+
+    // 4. Configure `tracing` to point to `opentelemetry`
+    let subscriber = Arc::new(tracing_subscriber::Registry::default().with(
+        tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer("multi_framework")),
+    ));
+
+    // 5. Run our example program
+    run_opentelemetry(tracer_provider.clone(), || {
+        log::info!("log in opentelemetry");
+        emit::info!("emit in opentelemetry");
+
+        run_tracing(subscriber.clone(), || {
+            log::info!("log in tracing");
+            emit::info!("emit in tracing");
+
+            run_emit(|| {
+                log::info!("log in emit");
+                emit::info!("emit in emit");
+
+                run_tracing(subscriber.clone(), || {
+                    log::info!("log in tracing in emit");
+                    emit::info!("emit in tracing in emit");
+                });
+
+                run_opentelemetry(tracer_provider.clone(), || {
+                    log::info!("log in opentelemetry in emit");
+                    emit::info!("emit in opentelemetry in emit");
+                })
+            });
+        });
+
+        run_emit(|| {
+            log::info!("log in emit");
+            emit::info!("emit in emit");
+        });
+    });
+
+    // 6. Shutdown the SDK
+    let _ = logger_provider.shutdown();
+    let _ = tracer_provider.shutdown();
+}
+
+#[emit::span("run_emit")]
+fn run_emit(f: impl FnOnce()) {
+    f()
+}
+
+fn run_opentelemetry<T: opentelemetry::trace::TracerProvider>(tracer_provider: T, f: impl FnOnce())
+where
+    <T::Tracer as opentelemetry::trace::Tracer>::Span: Send + Sync + 'static,
+{
+    use opentelemetry::trace::Tracer;
+
+    tracer_provider
+        .tracer("run_opentelemetry")
+        .in_span("Running OTel", |_| f())
+}
+
+fn run_tracing<T: tracing::Subscriber + Send + Sync>(subscriber: T, f: impl FnOnce()) {
+    tracing::subscriber::with_default(subscriber, || {
+        let span = tracing::span!(tracing::Level::INFO, "run_tracing");
+        let _enter = span.enter();
+
+        f()
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,8 @@ fn main() {
 }
 ```
 
-Diagnostic events produced by the [`macro@emit::span`] macro are sent to an [`opentelemetry::trace::Tracer`] as an [`opentelemetry::trace::Span`] on completion. All other emitted events are sent to an [`opentelemetry::logs::Logger`] as [`opentelemetry::logs::LogRecord`]s.
+Diagnostic events produced by the [`macro@emit::span`] macro are sent to an [`opentelemetry::trace::Tracer`] as an [`opentelemetry::trace::Span`] on completion.
+All other emitted events are sent to an [`opentelemetry::logs::Logger`] as [`opentelemetry::logs::LogRecord`]s.
 
 # Span lifecycle
 
@@ -76,12 +77,13 @@ The following well-known `emit` properties are interpreted during span completio
 
 - `err`: Mapped onto the semantic `exception` event on the span, and the span's status will be set to `Error`.
 - `lvl`: If its value is `error`, the span's status will be set to `Error`.
+- `span_links`: Populates a set of links on the span.
 
 If the span doesn't have a meaningful name configured already, then the rendered message will be used.
 
 # Sampling
 
-By default, `emit` events will be excluded if they are inside an unsampled OpenTelemetry trace, even if that trace is marked as recorded. OpenTelemetry will still propagate sampling decisions, but `emit`'s own spans will not be constructed within the unsampled trace.
+By default, `emit` will exclude any of its own spans that are created within unsampled traces.
 
 You can change this behavior by overriding the filter using [`emit::Setup::emit_when`] on the value returned by [`setup`].
 
@@ -89,6 +91,7 @@ You can change this behavior by overriding the filter using [`emit::Setup::emit_
 
 `emit` doesn't track trace flags, trace state, or whether links are remote in its model.
 This information will be populated from the current span context.
+You can add span links through the OpenTelemetry SDK itself, even to spans created by `emit`, if you need to configure these.
 
 # Span parents
 
@@ -2262,6 +2265,46 @@ mod tests {
             ],
         )]
         fn emit_span() {}
+
+        emit_span();
+
+        let spans = spans.get_finished_spans().unwrap();
+
+        assert_eq!(1, spans.len());
+
+        assert_eq!(1, spans[0].links.links.len());
+
+        assert_eq!(
+            "4bf92f3577b34da6a3ce929d0e0e4736",
+            spans[0].links.links[0].span_context.trace_id().to_string()
+        );
+        assert_eq!(
+            "00f067aa0ba902b7",
+            spans[0].links.links[0].span_context.span_id().to_string()
+        );
+    }
+
+    #[test]
+    fn emit_span_span_links_from_otel() {
+        static SLOT: AmbientSlot = AmbientSlot::new();
+        let (_, spans, _, _) = build(&SLOT);
+
+        #[emit::span(
+            rt: SLOT.get(),
+            "emit span",
+        )]
+        fn emit_span() {
+            Context::current().span().add_link(
+                SpanContext::new(
+                    TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").unwrap(),
+                    SpanId::from_hex("00f067aa0ba902b7").unwrap(),
+                    TraceFlags::SAMPLED,
+                    true,
+                    TraceState::default(),
+                ),
+                Default::default(),
+            );
+        }
 
         emit_span();
 


### PR DESCRIPTION
This PR adds an example of running multiple frameworks together in the same application, using the OpenTelemetry SDK as a common target.