### PR TITLE
Update to `0.32` of the OpenTelemetry SDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ members = [
     "examples/multi_framework",
 ]
 
+[features]
+default = ["implicit_rt"]
+implicit_rt = ["emit/implicit_rt"]
+
 [dependencies.emit]
 version = "1"
 features = ["std", "serde", "implicit_internal_rt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ features = ["std", "serde", "implicit_internal_rt"]
 default-features = false
 
 [dependencies.opentelemetry_sdk]
-version = "0.31"
+version = "0.32"
 features = ["logs", "trace"]
 
 [dependencies.opentelemetry]
-version = "0.31"
+version = "0.32"
 features = ["logs", "trace"]
 
 [dependencies.serde]
@@ -37,11 +37,11 @@ version = "1.8"
 features = ["implicit_rt"]
 
 [dev-dependencies.opentelemetry_sdk]
-version = "0.31"
+version = "0.32"
 features = ["logs", "trace", "testing"]
 
 [dev-dependencies.opentelemetry-stdout]
-version = "0.31"
+version = "0.32"
 features = ["logs", "trace"]
 
 [dev-dependencies.serde]

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ version = "1"
 
 # add `emit_openetelemetry` with the same major/minor as the OpenTelemetry SDK
 [dependencies.emit_opentelemetry]
-version = "0.31"
+version = "0.32"
 
 [dependencies.opentelemetry_sdk]
-version = "0.31"
+version = "0.32"
 features = ["trace", "logs"]
 
 [dependencies.opentelemetry]
-version = "0.31"
+version = "0.32"
 features = ["trace", "logs"]
 ```
 
@@ -89,3 +89,10 @@ For more details on how to use `emit` once you've initialized it, see [the guide
 ## Versioning and compatibility
 
 `emit_opentelemetry` version `x.y.z` is compatible with `opentelemetry_sdk` version `x.y.*`.
+
+## Limitations
+
+The OpenTelemetry SDK's design imposes significant limitations on how other frameworks can integrate with it. For `emit` this means:
+
+- Traces must be started by the OpenTelemetry SDK using its configured sampler. Any `emit` spans created outside an active sampled OpenTelemetry trace will be discarded.
+- Any trace/span ids assigned by `emit` will be ignored, and assigned by the OpenTelemetry SDK instead. The trace/span ids exposed through `emit`'s context will reflect what's in the OpenTelemetry context.

--- a/examples/getting_started/Cargo.toml
+++ b/examples/getting_started/Cargo.toml
@@ -12,15 +12,15 @@ version = "1"
 path = "../../"
 
 [dependencies.opentelemetry_sdk]
-version = "0.31"
+version = "0.32"
 features = ["rt-tokio", "trace", "logs"]
 
 [dependencies.opentelemetry]
-version = "0.31"
+version = "0.32"
 features = ["trace", "logs"]
 
 [dependencies.opentelemetry-otlp]
-version = "0.31"
+version = "0.32"
 features = ["trace", "logs", "grpc-tonic", "gzip-tonic"]
 
 [dependencies.tonic]

--- a/examples/getting_started/src/main.rs
+++ b/examples/getting_started/src/main.rs
@@ -39,6 +39,8 @@ async fn main() {
     let _ = emit_opentelemetry::setup(logger_provider.clone(), tracer_provider.clone()).init();
 
     // Run our example program
+    // IMPORTANT: Traces must be started through the OpenTelemetry SDK. `emit`'s integration
+    // discards any of its own `#[span]` events unless there's already an OpenTelemetry trace active.
     run_opentelemetry(tracer_provider.clone());
 
     // Shutdown the SDK

--- a/examples/multi_framework/Cargo.toml
+++ b/examples/multi_framework/Cargo.toml
@@ -16,7 +16,7 @@ path = "../../"
 version = "0.4"
 
 [dependencies.opentelemetry-appender-log]
-version = "0.31"
+version = "0.32"
 
 # tracing
 [dependencies.tracing]
@@ -26,19 +26,19 @@ version = "0.1"
 version = "0.3"
 
 [dependencies.tracing-opentelemetry]
-version = "0.32"
+version = "0.33"
 
 # opentelemetry
 [dependencies.opentelemetry_sdk]
-version = "0.31"
+version = "0.32"
 features = ["rt-tokio", "trace", "logs"]
 
 [dependencies.opentelemetry]
-version = "0.31"
+version = "0.32"
 features = ["trace", "logs"]
 
 [dependencies.opentelemetry-otlp]
-version = "0.31"
+version = "0.32"
 features = ["trace", "logs", "grpc-tonic", "gzip-tonic"]
 
 [dependencies.tonic]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,6 +333,7 @@ where
     /**
     Initialize `emit`'s global runtime to forward to the OpenTelemetry SDK.
     */
+    #[cfg(feature = "implicit_rt")]
     pub fn init(self) -> emit::setup::Init<'static, impl emit::Emitter, impl emit::Ctxt> {
         self.inner.init()
     }
@@ -340,6 +341,7 @@ where
     /**
     Try to initialize `emit`'s global runtime to forward to the OpenTelemetry SDK.
     */
+    #[cfg(feature = "implicit_rt")]
     pub fn try_init(
         self,
     ) -> Option<emit::setup::Init<'static, impl emit::Emitter, impl emit::Ctxt>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ use opentelemetry::{
 };
 
 use emit::runtime::AmbientSlot;
-use std::{borrow::Cow, cell::RefCell, fmt, ops::ControlFlow, sync::Arc};
+use std::{borrow::Cow, cell::RefCell, fmt, mem, ops::ControlFlow, sync::Arc};
 
 mod internal_metrics;
 
@@ -243,7 +243,7 @@ where
                 metrics.clone(),
                 logger_provider.logger(name),
             ))
-            .emit_when(OpenTelemetryIsSampledFilter {})
+            .emit_when(OpenTelemetryIncomingFilter {})
             .map_ctxt(|ctxt| {
                 OpenTelemetryCtxt::wrap(metrics.clone(), tracer_provider.tracer(name), ctxt)
             }),
@@ -258,7 +258,7 @@ pub struct Setup<L, T> {
     metrics: Arc<InternalMetrics>,
     inner: emit::Setup<
         OpenTelemetryEmitter<L>,
-        OpenTelemetryIsSampledFilter,
+        OpenTelemetryIncomingFilter,
         OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
         emit::Empty,
         emit::Empty,
@@ -277,12 +277,12 @@ where
     pub fn with_span_name(
         mut self,
         writer: impl Fn(
-            &emit::event::Event<&dyn emit::props::ErasedProps>,
-            &mut fmt::Formatter,
-        ) -> fmt::Result
-        + Send
-        + Sync
-        + 'static,
+                &emit::event::Event<&dyn emit::props::ErasedProps>,
+                &mut fmt::Formatter,
+            ) -> fmt::Result
+            + Send
+            + Sync
+            + 'static,
     ) -> Self {
         Setup {
             metrics: self.metrics,
@@ -301,12 +301,12 @@ where
     pub fn with_log_body(
         mut self,
         writer: impl Fn(
-            &emit::event::Event<&dyn emit::props::ErasedProps>,
-            &mut fmt::Formatter,
-        ) -> fmt::Result
-        + Send
-        + Sync
-        + 'static,
+                &emit::event::Event<&dyn emit::props::ErasedProps>,
+                &mut fmt::Formatter,
+            ) -> fmt::Result
+            + Send
+            + Sync
+            + 'static,
     ) -> Self {
         Setup {
             metrics: self.metrics,
@@ -333,13 +333,7 @@ where
     /**
     Initialize `emit`'s global runtime to forward to the OpenTelemetry SDK.
     */
-    pub fn init(
-        self,
-    ) -> emit::setup::Init<
-        'static,
-        OpenTelemetryEmitter<L>,
-        OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
-    > {
+    pub fn init(self) -> emit::setup::Init<'static, impl emit::Emitter, impl emit::Ctxt> {
         self.inner.init()
     }
 
@@ -348,13 +342,7 @@ where
     */
     pub fn try_init(
         self,
-    ) -> Option<
-        emit::setup::Init<
-            'static,
-            OpenTelemetryEmitter<L>,
-            OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
-        >,
-    > {
+    ) -> Option<emit::setup::Init<'static, impl emit::Emitter, impl emit::Ctxt>> {
         self.inner.try_init()
     }
 
@@ -364,11 +352,7 @@ where
     pub fn init_slot<'a>(
         self,
         slot: &'a AmbientSlot,
-    ) -> emit::setup::Init<
-        'a,
-        OpenTelemetryEmitter<L>,
-        OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
-    > {
+    ) -> emit::setup::Init<'a, impl emit::Emitter, impl emit::Ctxt> {
         self.inner.init_slot(slot)
     }
 
@@ -378,13 +362,7 @@ where
     pub fn try_init_slot<'a>(
         self,
         slot: &'a AmbientSlot,
-    ) -> Option<
-        emit::setup::Init<
-            'a,
-            OpenTelemetryEmitter<L>,
-            OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
-        >,
-    > {
+    ) -> Option<emit::setup::Init<'a, impl emit::Emitter, impl emit::Ctxt>> {
         self.inner.try_init_slot(slot)
     }
 }
@@ -396,7 +374,7 @@ This type is responsible for intercepting calls that push span state to `emit`'s
 
 When [`macro@emit::span`] is called, an [`opentelemetry::trace::Span`] is started using the given trace and span ids. The span doesn't carry any other ambient properties until it's completed either through [`emit::span::SpanGuard::complete`], or at the end of the scope the [`macro@emit::span`] macro covers.
 */
-pub struct OpenTelemetryCtxt<C, T> {
+struct OpenTelemetryCtxt<C, T> {
     tracer: T,
     metrics: Arc<InternalMetrics>,
     inner: C,
@@ -405,7 +383,7 @@ pub struct OpenTelemetryCtxt<C, T> {
 /**
 The [`emit::Ctxt::Frame`] used by [`OpenTelemetryCtxt`].
 */
-pub struct OpenTelemetryFrame<F> {
+struct OpenTelemetryFrame<F> {
     // Holds the OpenTelemetry context fetched when the span was started
     // If this field is `None`, and `active` is true then the slot has been
     // moved into the thread-local stack
@@ -433,7 +411,7 @@ struct OpenTelemetryFrameOptions {
 /**
 The [`emit::Ctxt::Current`] used by [`OpenTelemetryCtxt`].
 */
-pub struct OpenTelemetryProps<P: ?Sized> {
+struct OpenTelemetryProps<P: ?Sized> {
     ctxt: emit::span::SpanCtxt,
     // Props from the wrapped `Ctxt`
     inner: *const P,
@@ -631,6 +609,39 @@ where
     }
 }
 
+thread_local! {
+    static INCOMING_SPAN_PROPS: RefCell<IncomingSpanProps> = RefCell::new(Default::default());
+}
+
+#[derive(Default)]
+struct IncomingSpanProps {
+    trace_id: Option<emit::TraceId>,
+    span_parent: Option<emit::SpanId>,
+    span_name: Option<emit::Str<'static>>,
+    span_kind: Option<emit::span::SpanKind>,
+}
+
+fn populate_incoming_span_ctxt(props: impl emit::Props) {
+    let span_kind = props.pull::<emit::span::SpanKind, _>(KEY_SPAN_KIND);
+
+    let span_name = props
+        .pull::<emit::Str, _>(KEY_SPAN_NAME)
+        .map(|v| v.to_owned());
+
+    let trace_id = props.pull::<emit::TraceId, _>(KEY_TRACE_ID);
+
+    let span_parent = props.pull::<emit::SpanId, _>(KEY_SPAN_PARENT);
+
+    INCOMING_SPAN_PROPS.with(|incoming| {
+        *incoming.borrow_mut() = IncomingSpanProps {
+            trace_id,
+            span_parent,
+            span_name,
+            span_kind,
+        }
+    });
+}
+
 fn incoming_span_ctxt<T: Tracer>(
     tracer: &T,
     props: impl emit::Props,
@@ -638,18 +649,21 @@ fn incoming_span_ctxt<T: Tracer>(
 where
     T::Span: Send + Sync + 'static,
 {
+    let IncomingSpanProps {
+        trace_id,
+        span_parent,
+        span_name,
+        span_kind,
+    } = INCOMING_SPAN_PROPS.with(|incoming| mem::take(&mut *incoming.borrow_mut()));
+
     let ctxt = Context::current();
 
-    let incoming_trace_id = props
-        .pull::<emit::TraceId, _>(KEY_TRACE_ID)
-        .map(otel_trace_id);
-    let incoming_span_parent = props
-        .pull::<emit::SpanId, _>(KEY_SPAN_PARENT)
-        .map(otel_span_id);
+    let trace_id = trace_id.map(otel_trace_id);
+    let span_parent = span_parent.map(otel_span_id);
 
     // Only open a span if the incoming context follows on from it
-    if incoming_trace_id != Some(ctxt.span().span_context().trace_id())
-        || incoming_span_parent != Some(ctxt.span().span_context().span_id())
+    if trace_id != Some(ctxt.span().span_context().trace_id())
+        || span_parent != Some(ctxt.span().span_context().span_id())
     {
         return (
             IncomingSpanCtxt::None,
@@ -665,20 +679,7 @@ where
     // Note that only properties that are needed on span construction are
     // handled here. Other span properties will be mapped when the span is emitted
 
-    let span_links = props
-        .get(KEY_SPAN_LINKS)
-        .map(|links| {
-            otel_span_links(
-                links,
-                ctxt.span().span_context().trace_flags(),
-                ctxt.span().span_context().is_remote(),
-                ctxt.span().span_context().trace_state(),
-            )
-        })
-        .unwrap_or_default();
-
-    let span_kind = props
-        .pull::<emit::span::SpanKind, _>(KEY_SPAN_KIND)
+    let span_kind = span_kind
         .map(|kind| match kind {
             emit::span::SpanKind::Client => SpanKind::Client,
             emit::span::SpanKind::Server => SpanKind::Server,
@@ -688,7 +689,8 @@ where
         })
         .unwrap_or(SpanKind::Internal);
 
-    let span_name = props.pull::<String, _>(KEY_SPAN_NAME).map(Cow::Owned);
+    // TODO: `emit::Str::into_cow`
+    let span_name = span_name.map(|name| name.to_cow());
 
     // If the props include a span name then don't change it when completing the span
     // We need to track this in our own frame type because the OTel SDK doesn't expose
@@ -698,8 +700,6 @@ where
     let mut span = tracer
         .span_builder(span_name.unwrap_or(Cow::Borrowed("emit_span")))
         .with_kind(span_kind);
-
-    span = span.with_links(span_links);
 
     let ctxt = ctxt.with_span(span.start(tracer));
 
@@ -758,7 +758,7 @@ An [`emit::Emitter`] creating during [`setup`] for integrating `emit` with the O
 
 This type is responsible for emitting diagnostic events as log records through the OpenTelemetry SDK and completing spans created through the integration.
 */
-pub struct OpenTelemetryEmitter<L> {
+struct OpenTelemetryEmitter<L> {
     logger: L,
     span_name: Box<MessageFormatter>,
     log_body: Box<MessageFormatter>,
@@ -833,7 +833,7 @@ impl<L: Logger> emit::Emitter for OpenTelemetryEmitter<L> {
                         let mut status_is_descriptive_err = false;
                         let mut span_links = Vec::new();
 
-                        let _ = evt.props().for_each(|k, v| {
+                        let _ = evt.props().dedup().for_each(|k, v| {
                             if k == KEY_LVL {
                                 if let Some(emit::Level::Error) = v.by_ref().cast::<emit::Level>() {
                                     // Only set the status if we haven't given it a more descriptive value already
@@ -868,13 +868,27 @@ impl<L: Logger> emit::Emitter for OpenTelemetryEmitter<L> {
                                 return ControlFlow::Continue(());
                             }
 
+                            if k == KEY_SPAN_NAME {
+                                // NOTE: We don't know whether the name we're looking at now
+                                // is different from what we saw on construction. If it is the
+                                // same then they'll both be `&'static str`, which is cheap to
+                                // re-assign
+                                // TODO: `emit::Str::into_cow`
+                                span.update_name(
+                                    v.by_ref()
+                                        .cast::<emit::Str>()
+                                        .map(|v| v.to_cow())
+                                        .unwrap_or_else(|| Cow::Owned(v.to_string())),
+                                );
+                                frame.options.update_default_name_on_close = false;
+                            }
+
                             // Ignored; these are all handled during span construction
                             if k == KEY_TRACE_ID
                                 || k == KEY_SPAN_ID
                                 || k == KEY_SPAN_PARENT
                                 || k == KEY_EVT_KIND
                                 || k == KEY_SPAN_KIND
-                                || k == KEY_SPAN_NAME
                             {
                                 return ControlFlow::Continue(());
                             }
@@ -1027,15 +1041,21 @@ impl<L: Logger> emit::Emitter for OpenTelemetryEmitter<L> {
 /**
 A filter that excludes span events inside an unsampled trace.
 */
-pub struct OpenTelemetryIsSampledFilter {}
+struct OpenTelemetryIncomingFilter {}
 
-impl emit::Filter for OpenTelemetryIsSampledFilter {
+impl emit::Filter for OpenTelemetryIncomingFilter {
     fn matches<E: emit::event::ToEvent>(&self, evt: E) -> bool {
         let evt = evt.to_event();
 
         // If the event is a span then only include it if it matches the current OTel span context
         if emit::kind::is_span_filter().matches(&evt) {
-            Context::current().span().span_context().is_sampled()
+            if Context::current().span().span_context().is_sampled() {
+                populate_incoming_span_ctxt(evt.props());
+
+                true
+            } else {
+                false
+            }
         } else {
             // If the event is not a span then include it
             true
@@ -2218,13 +2238,76 @@ mod tests {
     }
 
     #[test]
-    fn otel_span_emit_span_name() {
-        todo!()
+    fn otel_span_emit_span_name_default() {
+        static SLOT: AmbientSlot = AmbientSlot::new();
+        let (_, spans, _, tracer_provider) = build(&SLOT);
+
+        let ctxt = otel_span(&tracer_provider, |_| emit_span!(SLOT, |_| {}));
+
+        let spans = spans.get_finished_spans().unwrap();
+
+        assert_eq!(2, spans.len());
+
+        assert_eq!("emit span", spans[0].name);
     }
 
     #[test]
-    fn otel_span_emit_span_kind() {
-        todo!()
+    fn otel_span_emit_span_name_guard_props() {
+        static SLOT: AmbientSlot = AmbientSlot::new();
+        let (_, spans, _, tracer_provider) = build(&SLOT);
+
+        let ctxt = otel_span(&tracer_provider, |_| {
+            #[emit::span(rt: SLOT.get(), guard: span, "emit span")]
+            fn emit_span() {
+                let _span = span.with_name("custom");
+            }
+
+            emit_span();
+        });
+
+        let spans = spans.get_finished_spans().unwrap();
+
+        assert_eq!(2, spans.len());
+
+        assert_eq!("custom", spans[0].name);
+    }
+
+    #[test]
+    fn otel_span_emit_span_kind_ctxt_props() {
+        static SLOT: AmbientSlot = AmbientSlot::new();
+        let (_, spans, _, tracer_provider) = build(&SLOT);
+
+        let ctxt = otel_span(&tracer_provider, |_| {
+            #[emit::span(rt: SLOT.get(), "emit span", span_kind: "client")]
+            fn emit_span() {}
+
+            emit_span();
+        });
+
+        let spans = spans.get_finished_spans().unwrap();
+
+        assert_eq!(2, spans.len());
+
+        assert_eq!(SpanKind::Client, spans[0].span_kind);
+    }
+
+    #[test]
+    fn otel_span_emit_span_kind_evt_props() {
+        static SLOT: AmbientSlot = AmbientSlot::new();
+        let (_, spans, _, tracer_provider) = build(&SLOT);
+
+        let ctxt = otel_span(&tracer_provider, |_| {
+            #[emit::span(rt: SLOT.get(), evt_props: ("span_kind", "client"), "emit span")]
+            fn emit_span() {}
+
+            emit_span();
+        });
+
+        let spans = spans.get_finished_spans().unwrap();
+
+        assert_eq!(2, spans.len());
+
+        assert_eq!(SpanKind::Client, spans[0].span_kind);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,15 +126,13 @@ fn main() {
 
     let mut reporter = emit::metric::Reporter::new();
 
-    let rt = emit_opentelemetry::setup(logger_provider, tracer_provider)
-        .map_emitter(|emitter| {
-            // 2. Add `emit_opentelemetry`'s metrics to a reporter so we can see what it's up to
-            //    You can do this independently of the internal emitter
-            reporter.add_source(emitter.metric_source());
+    let setup = emit_opentelemetry::setup(logger_provider, tracer_provider);
 
-            emitter
-        })
-        .init();
+    // 2. Add `emit_opentelemetry`'s metrics to a reporter so we can see what it's up to
+    //    You can do this independently of the internal emitter
+    reporter.add_source(setup.metric_source());
+
+    let rt = setup.init();
 
     // Your app code goes here
 
@@ -215,10 +213,8 @@ fn main() {
         .build();
 
     let rt = emit_opentelemetry::setup(logger_provider, tracer_provider)
-        .map_emitter(|emitter| emitter
-            .with_log_body(|evt, f| write!(f, "{}", evt.tpl()))
-            .with_span_name(|evt, f| write!(f, "{}", evt.tpl()))
-        )
+        .with_log_body(|evt, f| write!(f, "{}", evt.tpl()))
+        .with_span_name(|evt, f| write!(f, "{}", evt.tpl()))
         .init();
 
     // Your app code goes here
@@ -239,8 +235,8 @@ where
     let name = "emit";
     let metrics = Arc::new(InternalMetrics::default());
 
-    Setup(
-        emit::setup()
+    Setup {
+        inner: emit::setup()
             .with_clock(emit::Empty)
             .with_rng(emit::Empty)
             .emit_to(OpenTelemetryEmitter::new(
@@ -251,26 +247,89 @@ where
             .map_ctxt(|ctxt| {
                 OpenTelemetryCtxt::wrap(metrics.clone(), tracer_provider.tracer(name), ctxt)
             }),
-    )
+        metrics,
+    }
 }
 
 /**
 A partly initialized OpenTelemetry provider.
 */
-pub struct Setup<L, T>(
-    emit::Setup<
+pub struct Setup<L, T> {
+    metrics: Arc<InternalMetrics>,
+    inner: emit::Setup<
         OpenTelemetryEmitter<L>,
         OpenTelemetryIsSampledFilter,
         OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
         emit::Empty,
         emit::Empty,
     >,
-);
+}
 
 impl<L: Logger + Send + Sync + 'static, T: Tracer + Send + Sync + 'static> Setup<L, T>
 where
     T::Span: Send + Sync + 'static,
 {
+    /**
+    Specify a function that gets the name of a span from a diagnostic event.
+
+    The default implementation uses the [`KEY_SPAN_NAME`] property on the event, or [`emit::Event::msg`] if it's not present.
+    */
+    pub fn with_span_name(
+        mut self,
+        writer: impl Fn(
+            &emit::event::Event<&dyn emit::props::ErasedProps>,
+            &mut fmt::Formatter,
+        ) -> fmt::Result
+        + Send
+        + Sync
+        + 'static,
+    ) -> Self {
+        Setup {
+            metrics: self.metrics,
+            inner: self.inner.map_emitter(|mut emitter| {
+                emitter.span_name = Box::new(writer);
+                emitter
+            }),
+        }
+    }
+
+    /**
+    Specify a function that gets the body of a log record from a diagnostic event.
+
+    The default implementation uses [`emit::Event::msg`].
+    */
+    pub fn with_log_body(
+        mut self,
+        writer: impl Fn(
+            &emit::event::Event<&dyn emit::props::ErasedProps>,
+            &mut fmt::Formatter,
+        ) -> fmt::Result
+        + Send
+        + Sync
+        + 'static,
+    ) -> Self {
+        Setup {
+            metrics: self.metrics,
+            inner: self.inner.map_emitter(|mut emitter| {
+                emitter.log_body = Box::new(writer);
+                emitter
+            }),
+        }
+    }
+
+    /**
+    Get an [`emit::metric::Source`] for instrumentation produced by the `emit` to OpenTelemetry SDK integration.
+
+    These metrics are shared by [`OpenTelemetryCtxt::metric_source`].
+
+    These metrics can be used to monitor the running health of your diagnostic pipeline.
+    */
+    pub fn metric_source(&self) -> EmitOpenTelemetryMetrics {
+        EmitOpenTelemetryMetrics {
+            metrics: self.metrics.clone(),
+        }
+    }
+
     /**
     Initialize `emit`'s global runtime to forward to the OpenTelemetry SDK.
     */
@@ -281,7 +340,7 @@ where
         OpenTelemetryEmitter<L>,
         OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
     > {
-        self.0.init()
+        self.inner.init()
     }
 
     /**
@@ -296,7 +355,7 @@ where
             OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
         >,
     > {
-        self.0.try_init()
+        self.inner.try_init()
     }
 
     /**
@@ -310,7 +369,7 @@ where
         OpenTelemetryEmitter<L>,
         OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
     > {
-        self.0.init_slot(slot)
+        self.inner.init_slot(slot)
     }
 
     /**
@@ -326,7 +385,7 @@ where
             OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
         >,
     > {
-        self.0.try_init_slot(slot)
+        self.inner.try_init_slot(slot)
     }
 }
 
@@ -742,57 +801,6 @@ impl<L> OpenTelemetryEmitter<L> {
             span_name: default_span_name(),
             log_body: default_log_body(),
             metrics,
-        }
-    }
-
-    /**
-    Specify a function that gets the name of a span from a diagnostic event.
-
-    The default implementation uses the [`KEY_SPAN_NAME`] property on the event, or [`emit::Event::msg`] if it's not present.
-    */
-    pub fn with_span_name(
-        mut self,
-        writer: impl Fn(
-                &emit::event::Event<&dyn emit::props::ErasedProps>,
-                &mut fmt::Formatter,
-            ) -> fmt::Result
-            + Send
-            + Sync
-            + 'static,
-    ) -> Self {
-        self.span_name = Box::new(writer);
-        self
-    }
-
-    /**
-    Specify a function that gets the body of a log record from a diagnostic event.
-
-    The default implementation uses [`emit::Event::msg`].
-    */
-    pub fn with_log_body(
-        mut self,
-        writer: impl Fn(
-                &emit::event::Event<&dyn emit::props::ErasedProps>,
-                &mut fmt::Formatter,
-            ) -> fmt::Result
-            + Send
-            + Sync
-            + 'static,
-    ) -> Self {
-        self.log_body = Box::new(writer);
-        self
-    }
-
-    /**
-    Get an [`emit::metric::Source`] for instrumentation produced by the `emit` to OpenTelemetry SDK integration.
-
-    These metrics are shared by [`OpenTelemetryCtxt::metric_source`].
-
-    These metrics can be used to monitor the running health of your diagnostic pipeline.
-    */
-    pub fn metric_source(&self) -> EmitOpenTelemetryMetrics {
-        EmitOpenTelemetryMetrics {
-            metrics: self.metrics.clone(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ where
     The default implementation uses the [`KEY_SPAN_NAME`] property on the event, or [`emit::Event::msg`] if it's not present.
     */
     pub fn with_span_name(
-        mut self,
+        self,
         writer: impl Fn(
                 &emit::event::Event<&dyn emit::props::ErasedProps>,
                 &mut fmt::Formatter,
@@ -299,7 +299,7 @@ where
     The default implementation uses [`emit::Event::msg`].
     */
     pub fn with_log_body(
-        mut self,
+        self,
         writer: impl Fn(
                 &emit::event::Event<&dyn emit::props::ErasedProps>,
                 &mut fmt::Formatter,
@@ -423,19 +423,6 @@ impl<C, T> OpenTelemetryCtxt<C, T> {
             tracer,
             inner: ctxt,
             metrics,
-        }
-    }
-
-    /**
-    Get an [`emit::metric::Source`] for instrumentation produced by the `emit` to OpenTelemetry SDK integration.
-
-    These metrics are shared by [`OpenTelemetryEmitter::metric_source`].
-
-    These metrics can be used to monitor the running health of your diagnostic pipeline.
-    */
-    pub fn metric_source(&self) -> EmitOpenTelemetryMetrics {
-        EmitOpenTelemetryMetrics {
-            metrics: self.metrics.clone(),
         }
     }
 }
@@ -689,15 +676,14 @@ where
         })
         .unwrap_or(SpanKind::Internal);
 
-    // TODO: `emit::Str::into_cow`
-    let span_name = span_name.map(|name| name.to_cow());
+    let span_name = span_name.map(|name| name.into_cow());
 
     // If the props include a span name then don't change it when completing the span
     // We need to track this in our own frame type because the OTel SDK doesn't expose
     // the name after construction
     let update_default_name_on_close = span_name.is_none();
 
-    let mut span = tracer
+    let span = tracer
         .span_builder(span_name.unwrap_or(Cow::Borrowed("emit_span")))
         .with_kind(span_kind);
 
@@ -873,11 +859,10 @@ impl<L: Logger> emit::Emitter for OpenTelemetryEmitter<L> {
                                 // is different from what we saw on construction. If it is the
                                 // same then they'll both be `&'static str`, which is cheap to
                                 // re-assign
-                                // TODO: `emit::Str::into_cow`
                                 span.update_name(
                                     v.by_ref()
                                         .cast::<emit::Str>()
-                                        .map(|v| v.to_cow())
+                                        .map(|v| v.into_cow())
                                         .unwrap_or_else(|| Cow::Owned(v.to_string())),
                                 );
                                 frame.options.update_default_name_on_close = false;
@@ -2039,8 +2024,6 @@ mod tests {
 
     use emit::runtime::AmbientSlot;
 
-    use opentelemetry::trace::TraceState;
-
     use opentelemetry_sdk::trace::Sampler;
     use opentelemetry_sdk::{
         logs::{in_memory_exporter::InMemoryLogExporter, SdkLoggerProvider},
@@ -2198,7 +2181,7 @@ mod tests {
     #[test]
     fn emit_span() {
         static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, spans, _, tracer_provider) = build(&SLOT);
+        let (_, spans, _, _) = build(&SLOT);
 
         // Spans outside sampled traces are ignored
         let ctxt = emit_span!(SLOT, |ctxt| ctxt);
@@ -2242,7 +2225,7 @@ mod tests {
         static SLOT: AmbientSlot = AmbientSlot::new();
         let (_, spans, _, tracer_provider) = build(&SLOT);
 
-        let ctxt = otel_span(&tracer_provider, |_| emit_span!(SLOT, |_| {}));
+        otel_span(&tracer_provider, |_| emit_span!(SLOT, |_| {}));
 
         let spans = spans.get_finished_spans().unwrap();
 
@@ -2252,11 +2235,30 @@ mod tests {
     }
 
     #[test]
+    fn otel_span_emit_span_name_control_param() {
+        static SLOT: AmbientSlot = AmbientSlot::new();
+        let (_, spans, _, tracer_provider) = build(&SLOT);
+
+        otel_span(&tracer_provider, |_| {
+            #[emit::span(rt: SLOT.get(), name: "custom", "emit span")]
+            fn emit_span() {}
+
+            emit_span();
+        });
+
+        let spans = spans.get_finished_spans().unwrap();
+
+        assert_eq!(2, spans.len());
+
+        assert_eq!("custom", spans[0].name);
+    }
+
+    #[test]
     fn otel_span_emit_span_name_guard_props() {
         static SLOT: AmbientSlot = AmbientSlot::new();
         let (_, spans, _, tracer_provider) = build(&SLOT);
 
-        let ctxt = otel_span(&tracer_provider, |_| {
+        otel_span(&tracer_provider, |_| {
             #[emit::span(rt: SLOT.get(), guard: span, "emit span")]
             fn emit_span() {
                 let _span = span.with_name("custom");
@@ -2277,7 +2279,7 @@ mod tests {
         static SLOT: AmbientSlot = AmbientSlot::new();
         let (_, spans, _, tracer_provider) = build(&SLOT);
 
-        let ctxt = otel_span(&tracer_provider, |_| {
+        otel_span(&tracer_provider, |_| {
             #[emit::span(rt: SLOT.get(), "emit span", span_kind: "client")]
             fn emit_span() {}
 
@@ -2296,7 +2298,7 @@ mod tests {
         static SLOT: AmbientSlot = AmbientSlot::new();
         let (_, spans, _, tracer_provider) = build(&SLOT);
 
-        let ctxt = otel_span(&tracer_provider, |_| {
+        otel_span(&tracer_provider, |_| {
             #[emit::span(rt: SLOT.get(), evt_props: ("span_kind", "client"), "emit span")]
             fn emit_span() {}
 
@@ -2311,13 +2313,78 @@ mod tests {
     }
 
     #[test]
-    fn otel_span_emit_span_links() {
-        todo!()
+    fn otel_span_emit_span_links_guard_props() {
+        static SLOT: AmbientSlot = AmbientSlot::new();
+        let (_, spans, _, tracer_provider) = build(&SLOT);
+
+        otel_span(&tracer_provider, |_| {
+            #[emit::span(rt: SLOT.get(), guard: span, "emit span")]
+            fn emit_span() {
+                let _span = span.push_prop(
+                    "span_links",
+                    ["4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7"],
+                );
+            }
+
+            emit_span();
+        });
+
+        let spans = spans.get_finished_spans().unwrap();
+
+        assert_eq!(2, spans.len());
+
+        assert_eq!(1, spans[0].links.links.len());
+
+        assert_eq!(
+            "4bf92f3577b34da6a3ce929d0e0e4736",
+            spans[0].links.links[0].span_context.trace_id().to_string()
+        );
+        assert_eq!(
+            "00f067aa0ba902b7",
+            spans[0].links.links[0].span_context.span_id().to_string()
+        );
     }
 
     #[test]
-    fn otel_span_emit_span_err() {
-        todo!()
+    fn otel_span_emit_span_ok_control_param() {
+        static SLOT: AmbientSlot = AmbientSlot::new();
+        let (_, spans, _, tracer_provider) = build(&SLOT);
+
+        otel_span(&tracer_provider, |_| {
+            #[emit::span(rt: SLOT.get(), ok_lvl: "info", "emit span")]
+            fn emit_span() -> Result<(), io::Error> {
+                Ok(())
+            }
+
+            let _ = emit_span();
+        });
+
+        let spans = spans.get_finished_spans().unwrap();
+
+        assert_eq!(2, spans.len());
+
+        assert_eq!(Status::Ok, spans[0].status);
+    }
+
+    #[test]
+    fn otel_span_emit_span_err_control_param() {
+        static SLOT: AmbientSlot = AmbientSlot::new();
+        let (_, spans, _, tracer_provider) = build(&SLOT);
+
+        otel_span(&tracer_provider, |_| {
+            #[emit::span(rt: SLOT.get(), ok_lvl: "info", "emit span")]
+            fn emit_span() -> Result<(), io::Error> {
+                Err(io::Error::new(io::ErrorKind::Other, "something failed!"))
+            }
+
+            let _ = emit_span();
+        });
+
+        let spans = spans.get_finished_spans().unwrap();
+
+        assert_eq!(2, spans.len());
+
+        assert_eq!(Status::error("something failed!"), spans[0].status);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,17 +62,14 @@ All other emitted events are sent to an [`opentelemetry::logs::Logger`] as [`ope
 Spans created by `emit`'s `#[emit::span]` attribute will be created through the configured [`opentelemetry::trace::TracerProvider`].
 The following well-known `emit` properties are interpreted during span creation:
 
-- `span_id`: Sets the id of the span. If the id matches the current span then no new span will be created.
-- `trace_id`: Sets the trace id of the span. Otherwise the current trace id will be used.
 - `span_name`: Sets the name of the span. Otherwise a default name derived from the span's message template will be used.
 - `span_kind`: Sets the kind of the span. Otherwise the default kind of _internal_ will be used.
 - `span_links`: Populates a set of links on the span.
 
 Spans created through `emit` don't carry additional attributes on them until completion.
 
-Spans are completed either by emitting an event manually, or when the function annotated with `#[emit::span]` completes.
+Spans are completed when the function annotated with `#[emit::span]` completes.
 At this point if the event is a span, and its context matches the current OpenTelemetry span context, it'll be emitted as a span.
-Otherwise it'll be emitted as a regular log event.
 The following well-known `emit` properties are interpreted during span completion:
 
 - `err`: Mapped onto the semantic `exception` event on the span, and the span's status will be set to `Error`.
@@ -83,9 +80,8 @@ If the span doesn't have a meaningful name configured already, then the rendered
 
 # Sampling
 
-By default, `emit` will exclude any of its own spans that are created within unsampled traces.
-
-You can change this behavior by overriding the filter using [`emit::Setup::emit_when`] on the value returned by [`setup`].
+`emit` will respect the sampling decision in OpenTelemetry's context. Spans outside of sampled OpenTelemetry traces _will not be emitted_.
+That means the root span _must_ be created by the OpenTelemetry SDK, not by `emit`.
 
 # Span links
 
@@ -93,16 +89,13 @@ You can change this behavior by overriding the filter using [`emit::Setup::emit_
 This information will be populated from the current span context.
 You can add span links through the OpenTelemetry SDK itself, even to spans created by `emit`, if you need to configure these.
 
-# Span parents
-
-When using `emit_opentelemetry`, any `SpanCtxt` pulled from ambient context won't carry a parent span id, even for non-root spans.
-This is because the OpenTelemetry SDK doesn't have an API for accessing the parent-child relationship of a span after its construction.
-
 # Limitations
 
 This library doesn't support `emit`'s metrics as OpenTelemetry metrics. Any metric samples produced by `emit` will be emitted as log records.
 
-Spans produced manually (without adding their trace ids and span ids to the shared [`emit::Ctxt`]) will be emitted as log events instead of as spans.
+Spans produced manually (without adding their trace ids and span ids to the shared [`emit::Ctxt`]) will not be emitted.
+
+Spans produced outside of a sampled OpenTelemetry trace will not be emitted. That means the root span _must_ be created by the OpenTelemetry SDK.
 
 # Troubleshooting
 
@@ -166,7 +159,7 @@ use emit::{
     },
     Filter as _, Props as _,
 };
-use opentelemetry::trace::{Link, SamplingDecision, SamplingResult, TraceState};
+use opentelemetry::trace::{Link, TraceState};
 use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
     trace::{
@@ -175,6 +168,7 @@ use opentelemetry::{
     Context, ContextGuard, Key, KeyValue, TraceFlags, Value,
 };
 
+use emit::runtime::AmbientSlot;
 use std::{borrow::Cow, cell::RefCell, fmt, ops::ControlFlow, sync::Arc};
 
 mod internal_metrics;
@@ -238,26 +232,102 @@ fn main() {
 pub fn setup<L: Logger + Send + Sync + 'static, T: Tracer + Send + Sync + 'static>(
     logger_provider: impl LoggerProvider<Logger = L>,
     tracer_provider: impl TracerProvider<Tracer = T>,
-) -> emit::Setup<
-    OpenTelemetryEmitter<L>,
-    OpenTelemetryIsSampledFilter,
-    OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
->
+) -> Setup<L, T>
 where
     T::Span: Send + Sync + 'static,
 {
     let name = "emit";
     let metrics = Arc::new(InternalMetrics::default());
 
-    emit::setup()
-        .emit_to(OpenTelemetryEmitter::new(
-            metrics.clone(),
-            logger_provider.logger(name),
-        ))
-        .emit_when(OpenTelemetryIsSampledFilter {})
-        .map_ctxt(|ctxt| {
-            OpenTelemetryCtxt::wrap(metrics.clone(), tracer_provider.tracer(name), ctxt)
-        })
+    Setup(
+        emit::setup()
+            .with_clock(emit::Empty)
+            .with_rng(emit::Empty)
+            .emit_to(OpenTelemetryEmitter::new(
+                metrics.clone(),
+                logger_provider.logger(name),
+            ))
+            .emit_when(OpenTelemetryIsSampledFilter {})
+            .map_ctxt(|ctxt| {
+                OpenTelemetryCtxt::wrap(metrics.clone(), tracer_provider.tracer(name), ctxt)
+            }),
+    )
+}
+
+/**
+A partly initialized OpenTelemetry provider.
+*/
+pub struct Setup<L, T>(
+    emit::Setup<
+        OpenTelemetryEmitter<L>,
+        OpenTelemetryIsSampledFilter,
+        OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
+        emit::Empty,
+        emit::Empty,
+    >,
+);
+
+impl<L: Logger + Send + Sync + 'static, T: Tracer + Send + Sync + 'static> Setup<L, T>
+where
+    T::Span: Send + Sync + 'static,
+{
+    /**
+    Initialize `emit`'s global runtime to forward to the OpenTelemetry SDK.
+    */
+    pub fn init(
+        self,
+    ) -> emit::setup::Init<
+        'static,
+        OpenTelemetryEmitter<L>,
+        OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
+    > {
+        self.0.init()
+    }
+
+    /**
+    Try to initialize `emit`'s global runtime to forward to the OpenTelemetry SDK.
+    */
+    pub fn try_init(
+        self,
+    ) -> Option<
+        emit::setup::Init<
+            'static,
+            OpenTelemetryEmitter<L>,
+            OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
+        >,
+    > {
+        self.0.try_init()
+    }
+
+    /**
+    Initialize an ambient runtime slot to forward to the OpenTelemetry SDK.
+    */
+    pub fn init_slot<'a>(
+        self,
+        slot: &'a AmbientSlot,
+    ) -> emit::setup::Init<
+        'a,
+        OpenTelemetryEmitter<L>,
+        OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
+    > {
+        self.0.init_slot(slot)
+    }
+
+    /**
+    Try to initialize an ambient runtime slot to forward to the OpenTelemetry SDK.
+    */
+    pub fn try_init_slot<'a>(
+        self,
+        slot: &'a AmbientSlot,
+    ) -> Option<
+        emit::setup::Init<
+            'a,
+            OpenTelemetryEmitter<L>,
+            OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
+        >,
+    > {
+        self.0.try_init_slot(slot)
+    }
 }
 
 /**
@@ -387,15 +457,13 @@ where
     type Frame = OpenTelemetryFrame<C::Frame>;
 
     fn open_root<P: emit::Props>(&self, props: P) -> Self::Frame {
-        let (incoming, props) = incoming_span_ctxt(&self.tracer, props, false);
+        let (incoming, props) = incoming_span_ctxt(&self.tracer, props);
 
         let (slot, options) = match incoming {
             // An empty root context should unset any active OTel context
             IncomingSpanCtxt::None => (Some(Context::new()), Default::default()),
-            // If the context is the same then don't track anything in this frame
-            IncomingSpanCtxt::Same => (None, Default::default()),
             // If the context is different then track it in this frame
-            IncomingSpanCtxt::Different(context, options) => (Some(context), options),
+            IncomingSpanCtxt::Span(context, options) => (Some(context), options),
         };
 
         OpenTelemetryFrame {
@@ -407,35 +475,24 @@ where
     }
 
     fn open_disabled<P: emit::Props>(&self, props: P) -> Self::Frame {
-        let (incoming, props) = incoming_span_ctxt(&self.tracer, props, true);
-
-        let (slot, options) = match incoming {
-            // An empty context and the same context are equivalent; neither track anything in this frame
-            IncomingSpanCtxt::None => (None, Default::default()),
-            IncomingSpanCtxt::Same => (None, Default::default()),
-            // If the context is different then track it in this frame
-            IncomingSpanCtxt::Different(context, options) => (Some(context), options),
-        };
-
         OpenTelemetryFrame {
             active: false,
-            options,
-            slot,
+            options: Default::default(),
+            slot: None,
             inner: self.inner.open_disabled(props),
         }
     }
 
     fn open_push<P: emit::Props>(&self, props: P) -> Self::Frame {
-        let (incoming, props) = incoming_span_ctxt(&self.tracer, props, false);
+        let (incoming, props) = incoming_span_ctxt(&self.tracer, props);
 
         let (slot, options) = match incoming {
             // An empty context and the same context are equivalent; neither track anything in this frame
             // Note that if the sampling decision changed without the span context changing we'll ignore it
             IncomingSpanCtxt::None => (None, Default::default()),
-            IncomingSpanCtxt::Same => (None, Default::default()),
             // If the context is different then track it in this frame
             // The context will be unsampled, so any downstream spans will also be unsampled
-            IncomingSpanCtxt::Different(context, options) => (Some(context), options),
+            IncomingSpanCtxt::Span(context, options) => (Some(context), options),
         };
 
         OpenTelemetryFrame {
@@ -518,31 +575,32 @@ where
 fn incoming_span_ctxt<T: Tracer>(
     tracer: &T,
     props: impl emit::Props,
-    suppress: bool,
 ) -> (IncomingSpanCtxt, impl emit::Props)
 where
     T::Span: Send + Sync + 'static,
 {
-    let span_id = props.pull::<emit::SpanId, _>(KEY_SPAN_ID);
-
-    let Some(span_id) = span_id else {
-        return (
-            IncomingSpanCtxt::None,
-            ExcludeSpanCtxtProps { inner: props },
-        );
-    };
-
     let ctxt = Context::current();
 
-    let span_id = otel_span_id(span_id);
+    let incoming_trace_id = props
+        .pull::<emit::TraceId, _>(KEY_TRACE_ID)
+        .map(otel_trace_id);
+    let incoming_span_parent = props
+        .pull::<emit::SpanId, _>(KEY_SPAN_PARENT)
+        .map(otel_span_id);
 
-    // Only open a span if the id has changed
-    if span_id == ctxt.span().span_context().span_id() {
+    // Only open a span if the incoming context follows on from it
+    if incoming_trace_id != Some(ctxt.span().span_context().trace_id())
+        || incoming_span_parent != Some(ctxt.span().span_context().span_id())
+    {
         return (
-            IncomingSpanCtxt::Same,
-            ExcludeSpanCtxtProps { inner: props },
+            IncomingSpanCtxt::None,
+            ExcludeSpanCtxtProps {
+                exclude_ctxt_props: true,
+                exclude_span_parent: true,
+                inner: props,
+            },
         );
-    }
+    };
 
     // Map `emit`'s well-known span properties into the OTel context
     // Note that only properties that are needed on span construction are
@@ -578,48 +636,33 @@ where
     // the name after construction
     let update_default_name_on_close = span_name.is_none();
 
-    let trace_id = props.pull::<emit::TraceId, _>(KEY_TRACE_ID);
-
-    let trace_id = trace_id.map(otel_trace_id);
-
     let mut span = tracer
         .span_builder(span_name.unwrap_or(Cow::Borrowed("emit_span")))
-        .with_kind(span_kind)
-        .with_span_id(span_id);
-
-    if let Some(trace_id) = trace_id {
-        span = span.with_trace_id(trace_id);
-    }
+        .with_kind(span_kind);
 
     span = span.with_links(span_links);
-
-    // If the context was discarded by `emit`'s filter then open it as disabled
-    if suppress {
-        span = span.with_sampling_result(SamplingResult {
-            decision: SamplingDecision::Drop,
-            attributes: vec![],
-            trace_state: Default::default(),
-        });
-    }
 
     let ctxt = ctxt.with_span(span.start(tracer));
 
     (
-        IncomingSpanCtxt::Different(
+        IncomingSpanCtxt::Span(
             ctxt,
             OpenTelemetryFrameOptions {
                 update_default_name_on_close,
                 end_on_close: true,
             },
         ),
-        ExcludeSpanCtxtProps { inner: props },
+        ExcludeSpanCtxtProps {
+            exclude_ctxt_props: true,
+            exclude_span_parent: false,
+            inner: props,
+        },
     )
 }
 
 enum IncomingSpanCtxt {
     None,
-    Same,
-    Different(Context, OpenTelemetryFrameOptions),
+    Span(Context, OpenTelemetryFrameOptions),
 }
 
 /**
@@ -627,6 +670,8 @@ A filter used when pushing properties into `emit`'s context that removes propert
 tracked by the OpenTelemetry SDK.
 */
 struct ExcludeSpanCtxtProps<P> {
+    exclude_ctxt_props: bool,
+    exclude_span_parent: bool,
     inner: P,
 }
 
@@ -637,8 +682,12 @@ impl<P: emit::Props> emit::Props for ExcludeSpanCtxtProps<P> {
     ) -> ControlFlow<()> {
         self.inner.for_each(|key, value| match key.get() {
             // Properties that come from the OTel context
-            KEY_TRACE_ID | KEY_SPAN_ID | KEY_SPAN_PARENT | KEY_SPAN_NAME | KEY_SPAN_KIND
-            | KEY_SPAN_LINKS => ControlFlow::Continue(()),
+            KEY_TRACE_ID | KEY_SPAN_ID | KEY_SPAN_NAME | KEY_SPAN_KIND | KEY_SPAN_LINKS
+                if self.exclude_ctxt_props =>
+            {
+                ControlFlow::Continue(())
+            }
+            KEY_SPAN_PARENT if self.exclude_span_parent => ControlFlow::Continue(()),
             // Properties to pass through to the underlying context
             _ => for_each(key, value),
         })
@@ -857,11 +906,11 @@ impl<L: Logger> emit::Emitter for OpenTelemetryEmitter<L> {
                 }
             });
 
-            if emitted {
-                return;
-            } else {
+            if !emitted {
                 self.metrics.span_unexpected_emit.increment();
             }
+
+            return;
         }
 
         // If the event wasn't emitted as a span then emit it as a log record
@@ -978,11 +1027,7 @@ impl emit::Filter for OpenTelemetryIsSampledFilter {
 
         // If the event is a span then only include it if it matches the current OTel span context
         if emit::kind::is_span_filter().matches(&evt) {
-            let ctxt = Context::current();
-            let span = ctxt.span();
-            let span_ctxt = span.span_context();
-
-            span_ctxt == &SpanContext::NONE || span_ctxt.is_sampled()
+            Context::current().span().span_context().is_sampled()
         } else {
             // If the event is not a span then include it
             true
@@ -1966,8 +2011,9 @@ mod tests {
 
     use emit::runtime::AmbientSlot;
 
-    use opentelemetry::trace::{SamplingDecision, SamplingResult, TraceState};
+    use opentelemetry::trace::TraceState;
 
+    use opentelemetry_sdk::trace::Sampler;
     use opentelemetry_sdk::{
         logs::{in_memory_exporter::InMemoryLogExporter, SdkLoggerProvider},
         trace::{in_memory_exporter::InMemorySpanExporter, SdkTracerProvider},
@@ -1975,6 +2021,18 @@ mod tests {
 
     fn build(
         slot: &AmbientSlot,
+    ) -> (
+        InMemoryLogExporter,
+        InMemorySpanExporter,
+        SdkLoggerProvider,
+        SdkTracerProvider,
+    ) {
+        build_with_sampler(slot, Sampler::AlwaysOn)
+    }
+
+    fn build_with_sampler(
+        slot: &AmbientSlot,
+        sampler: Sampler,
     ) -> (
         InMemoryLogExporter,
         InMemorySpanExporter,
@@ -1991,6 +2049,7 @@ mod tests {
 
         let tracer_provider = SdkTracerProvider::builder()
             .with_simple_exporter(tracer_exporter.clone())
+            .with_sampler(sampler)
             .build();
 
         let _ = setup(logger_provider.clone(), tracer_provider.clone()).init_slot(slot);
@@ -2001,6 +2060,33 @@ mod tests {
             logger_provider,
             tracer_provider,
         )
+    }
+
+    fn otel_span<T>(tracer_provider: &SdkTracerProvider, in_span: impl FnOnce(Context) -> T) -> T {
+        use opentelemetry::trace::TracerProvider;
+
+        tracer_provider
+            .tracer("otel_span")
+            .in_span("otel span", in_span)
+    }
+
+    macro_rules! emit_span {
+        ($slot:ident, $in_span:expr) => {{
+            #[emit::span(rt: $slot.get(), "emit span")]
+            fn emit_span<T>(in_span: impl FnOnce(emit::SpanCtxt) -> T) -> T {
+                in_span(emit::span::SpanCtxt::current($slot.get().ctxt()))
+            }
+
+            emit_span($in_span)
+        }};
+    }
+
+    fn emit_trace_id(trace_id: TraceId) -> emit::TraceId {
+        emit::TraceId::from_bytes(trace_id.to_bytes()).unwrap()
+    }
+
+    fn emit_span_id(span_id: SpanId) -> emit::SpanId {
+        emit::SpanId::from_bytes(span_id.to_bytes()).unwrap()
     }
 
     #[test]
@@ -2043,661 +2129,104 @@ mod tests {
     }
 
     #[test]
-    fn emit_span() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, spans, _, _) = build(&SLOT);
-
-        #[emit::span(rt: SLOT.get(), "emit {attr}", attr: "span")]
-        fn emit_span() -> emit::span::SpanCtxt {
-            emit::span::SpanCtxt::current(SLOT.get().ctxt())
-        }
-
-        let ctxt = emit_span();
-
-        let spans = spans.get_finished_spans().unwrap();
-
-        assert_eq!(1, spans.len());
-
-        assert_eq!("emit {attr}", spans[0].name);
-
-        assert_eq!(
-            ctxt.trace_id().unwrap().to_bytes(),
-            spans[0].span_context.trace_id().to_bytes()
-        );
-        assert_eq!(
-            ctxt.span_id().unwrap().to_bytes(),
-            spans[0].span_context.span_id().to_bytes()
-        );
-        assert!(ctxt.span_parent().is_none());
-        assert_eq!(
-            opentelemetry::trace::SpanId::INVALID,
-            spans[0].parent_span_id
-        );
-    }
-
-    #[test]
-    fn emit_span_direct() {
-        let slot = AmbientSlot::new();
-        let (logs, spans, _, _) = build(&slot);
-
-        emit::emit!(
-            rt: slot.get(),
-            evt: emit::Span::new(
-                emit::mdl!(),
-                "test",
-                "2024-01-01T00:00:00.000Z".parse::<emit::Timestamp>().unwrap().."2024-01-01T00:00:01.000Z".parse::<emit::Timestamp>().unwrap(),
-                emit::span::SpanCtxt::new_root(slot.get().rng()),
-            ),
-        );
-
-        let logs = logs.get_emitted_logs().unwrap();
-        let spans = spans.get_finished_spans().unwrap();
-
-        assert_eq!(1, logs.len());
-        assert_eq!(0, spans.len());
-    }
-
-    #[test]
-    fn emit_span_otel_span() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, spans, _, tracer_provider) = build(&SLOT);
-
-        #[emit::span(rt: SLOT.get(), "emit span")]
-        fn emit_span(tracer_provider: &SdkTracerProvider) -> (SpanContext, emit::span::SpanCtxt) {
-            fn otel_span(tracer_provider: &SdkTracerProvider) -> SpanContext {
-                use opentelemetry::trace::TracerProvider;
-
-                tracer_provider
-                    .tracer("otel_span")
-                    .in_span("otel span", |cx| cx.span().span_context().clone())
-            }
-
-            (
-                otel_span(&tracer_provider),
-                emit::span::SpanCtxt::current(SLOT.get().ctxt()),
-            )
-        }
-
-        let (otel_ctxt, emit_ctxt) = emit_span(&tracer_provider);
-
-        let spans = spans.get_finished_spans().unwrap();
-
-        assert_eq!(2, spans.len());
-
-        assert_eq!(
-            otel_ctxt.trace_id().to_bytes(),
-            emit_ctxt.trace_id().unwrap().to_bytes()
-        );
-
-        assert_eq!("otel span", spans[0].name);
-
-        assert_eq!(
-            otel_ctxt.trace_id().to_bytes(),
-            spans[0].span_context.trace_id().to_bytes()
-        );
-        assert_eq!(
-            otel_ctxt.span_id().to_bytes(),
-            spans[0].span_context.span_id().to_bytes()
-        );
-        assert_eq!(
-            emit_ctxt.span_id().unwrap().to_bytes(),
-            spans[0].parent_span_id.to_bytes()
-        );
-
-        assert_eq!("emit span", spans[1].name);
-
-        assert_eq!(
-            emit_ctxt.trace_id().unwrap().to_bytes(),
-            spans[1].span_context.trace_id().to_bytes()
-        );
-        assert_eq!(
-            emit_ctxt.span_id().unwrap().to_bytes(),
-            spans[1].span_context.span_id().to_bytes()
-        );
-        assert!(emit_ctxt.span_parent().is_none());
-    }
-
-    #[test]
-    fn emit_span_otel_log() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (logs, _, logger_provider, _) = build(&SLOT);
-
-        #[emit::span(rt: SLOT.get(), "emit span")]
-        fn emit_span(logger_provider: &SdkLoggerProvider) -> emit::span::SpanCtxt {
-            use opentelemetry::logs::LoggerProvider;
-
-            let logger = logger_provider.logger("otel_logger");
-
-            let mut log = logger.create_log_record();
-
-            log.set_body(AnyValue::String("test log".into()));
-
-            logger.emit(log);
-
-            emit::span::SpanCtxt::current(SLOT.get().ctxt())
-        }
-
-        let ctxt = emit_span(&logger_provider);
-
-        let logs = logs.get_emitted_logs().unwrap();
-
-        assert_eq!(1, logs.len());
-
-        assert!(logs[0]
-            .record
-            .trace_context()
-            .unwrap()
-            .trace_flags
-            .unwrap()
-            .is_sampled());
-
-        assert_eq!(
-            ctxt.trace_id().unwrap().to_bytes(),
-            logs[0].record.trace_context().unwrap().trace_id.to_bytes()
-        );
-        assert_eq!(
-            ctxt.span_id().unwrap().to_bytes(),
-            logs[0].record.trace_context().unwrap().span_id.to_bytes()
-        );
-    }
-
-    #[test]
-    fn emit_span_span_name() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, spans, _, _) = build(&SLOT);
-
-        #[emit::span(rt: SLOT.get(), "emit span", span_name: "custom name")]
-        fn emit_span() {}
-
-        emit_span();
-
-        let spans = spans.get_finished_spans().unwrap();
-
-        assert_eq!(1, spans.len());
-
-        assert_eq!("custom name", spans[0].name);
-    }
-
-    #[test]
-    fn emit_span_span_kind() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, spans, _, _) = build(&SLOT);
-
-        #[emit::span(rt: SLOT.get(), "emit span", span_kind: "producer")]
-        fn emit_span() {}
-
-        emit_span();
-
-        let spans = spans.get_finished_spans().unwrap();
-
-        assert_eq!(1, spans.len());
-
-        assert_eq!(SpanKind::Producer, spans[0].span_kind);
-    }
-
-    #[test]
-    fn emit_span_span_links() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, spans, _, _) = build(&SLOT);
-
-        #[emit::span(
-            rt: SLOT.get(),
-            "emit span",
-            #[emit::as_serde]
-            span_links: [
-                "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",
-            ],
-        )]
-        fn emit_span() {}
-
-        emit_span();
-
-        let spans = spans.get_finished_spans().unwrap();
-
-        assert_eq!(1, spans.len());
-
-        assert_eq!(1, spans[0].links.links.len());
-
-        assert_eq!(
-            "4bf92f3577b34da6a3ce929d0e0e4736",
-            spans[0].links.links[0].span_context.trace_id().to_string()
-        );
-        assert_eq!(
-            "00f067aa0ba902b7",
-            spans[0].links.links[0].span_context.span_id().to_string()
-        );
-    }
-
-    #[test]
-    fn emit_span_span_links_from_otel() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, spans, _, _) = build(&SLOT);
-
-        #[emit::span(
-            rt: SLOT.get(),
-            "emit span",
-        )]
-        fn emit_span() {
-            Context::current().span().add_link(
-                SpanContext::new(
-                    TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").unwrap(),
-                    SpanId::from_hex("00f067aa0ba902b7").unwrap(),
-                    TraceFlags::SAMPLED,
-                    true,
-                    TraceState::default(),
-                ),
-                Default::default(),
-            );
-        }
-
-        emit_span();
-
-        let spans = spans.get_finished_spans().unwrap();
-
-        assert_eq!(1, spans.len());
-
-        assert_eq!(1, spans[0].links.links.len());
-
-        assert_eq!(
-            "4bf92f3577b34da6a3ce929d0e0e4736",
-            spans[0].links.links[0].span_context.trace_id().to_string()
-        );
-        assert_eq!(
-            "00f067aa0ba902b7",
-            spans[0].links.links[0].span_context.span_id().to_string()
-        );
-    }
-
-    #[test]
-    fn emit_span_ok() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, spans, _, _) = build(&SLOT);
-
-        #[emit::span(rt: SLOT.get(), ok_lvl: "info", "emit span")]
-        fn emit_span() -> Result<(), io::Error> {
-            Ok(())
-        }
-
-        let _ = emit_span();
-
-        let spans = spans.get_finished_spans().unwrap();
-
-        assert_eq!(1, spans.len());
-
-        assert_eq!(Status::Ok, spans[0].status);
-    }
-
-    #[test]
-    fn emit_span_err() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, spans, _, _) = build(&SLOT);
-
-        #[emit::span(rt: SLOT.get(), err_lvl: "error", "emit span")]
-        fn emit_span() -> Result<(), io::Error> {
-            Err(io::Error::new(io::ErrorKind::Other, "something failed!"))
-        }
-
-        let _ = emit_span();
-
-        let spans = spans.get_finished_spans().unwrap();
-
-        assert_eq!(1, spans.len());
-
-        assert_eq!(Status::error("something failed!"), spans[0].status);
-    }
-
-    #[test]
-    fn emit_span_lvl_err() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, spans, _, _) = build(&SLOT);
-
-        #[emit::span(rt: SLOT.get(), ok_lvl: "error", "emit span")]
-        fn emit_span() -> Result<(), io::Error> {
-            Ok(())
-        }
-
-        let _ = emit_span();
-
-        let spans = spans.get_finished_spans().unwrap();
-
-        assert_eq!(1, spans.len());
-
-        assert_eq!(Status::error("error"), spans[0].status);
-    }
-
-    #[test]
-    fn emit_span_unsampled_otel_span() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, spans, _, tracer_provider) = build(&SLOT);
-
-        #[emit::span(rt: SLOT.get(), when: emit::filter::from_fn(|_| false), "emit span")]
-        fn emit_span(tracer_provider: &SdkTracerProvider) -> SpanContext {
-            fn otel_span(tracer_provider: &SdkTracerProvider) -> SpanContext {
-                use opentelemetry::trace::TracerProvider;
-
-                tracer_provider
-                    .tracer("otel_span")
-                    .in_span("otel span", |cx| cx.span().span_context().clone())
-            }
-
-            otel_span(&tracer_provider)
-        }
-
-        let otel_ctxt = emit_span(&tracer_provider);
-
-        let spans = spans.get_finished_spans().unwrap();
-
-        assert_eq!(0, spans.len());
-
-        assert!(!otel_ctxt.is_sampled());
-    }
-
-    #[test]
-    fn emit_span_unsampled_emit_span() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, spans, _, _) = build(&SLOT);
-
-        #[emit::span(rt: SLOT.get(), when: emit::filter::from_fn(|_| false), "emit span")]
-        fn emit_span_outer() {
-            #[emit::span(rt: SLOT.get(), "emit span")]
-            fn emit_span_inner() {}
-
-            emit_span_inner()
-        }
-
-        emit_span_outer();
-
-        let spans = spans.get_finished_spans().unwrap();
-
-        assert_eq!(0, spans.len());
-    }
-
-    #[test]
-    fn emit_span_unsampled_otel_log() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (logs, _, logger_provider, _) = build(&SLOT);
-
-        #[emit::span(rt: SLOT.get(), when: emit::filter::from_fn(|_| false), "emit span")]
-        fn emit_span(logger_provider: &SdkLoggerProvider) -> emit::span::SpanCtxt {
-            use opentelemetry::logs::LoggerProvider;
-
-            let logger = logger_provider.logger("otel_logger");
-
-            let mut log = logger.create_log_record();
-
-            log.set_body(AnyValue::String("test log".into()));
-
-            logger.emit(log);
-
-            emit::span::SpanCtxt::current(SLOT.get().ctxt())
-        }
-
-        let ctxt = emit_span(&logger_provider);
-
-        let logs = logs.get_emitted_logs().unwrap();
-
-        assert_eq!(1, logs.len());
-
-        assert!(!logs[0]
-            .record
-            .trace_context()
-            .unwrap()
-            .trace_flags
-            .unwrap()
-            .is_sampled());
-
-        assert_eq!(
-            ctxt.trace_id().unwrap().to_bytes(),
-            logs[0].record.trace_context().unwrap().trace_id.to_bytes()
-        );
-        assert_eq!(
-            ctxt.span_id().unwrap().to_bytes(),
-            logs[0].record.trace_context().unwrap().span_id.to_bytes()
-        );
-    }
-
-    #[test]
-    fn emit_ctxt_clear_otel_ctxt() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, _, _, tracer_provider) = build(&SLOT);
-
-        fn otel_span(tracer_provider: &SdkTracerProvider) -> SpanContext {
-            use opentelemetry::trace::TracerProvider;
-
-            tracer_provider
-                .tracer("otel_span")
-                .in_span("otel span", |_| {
-                    emit::Frame::root(SLOT.get().ctxt(), emit::Empty)
-                        .call(|| Context::current().span().span_context().clone())
-                })
-        }
-
-        let cx = otel_span(&tracer_provider);
-
-        assert_eq!(SpanContext::NONE, cx);
-    }
-
-    #[test]
-    fn emit_ctxt_push_otel_ctxt() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (_, _, _, tracer_provider) = build(&SLOT);
-
-        fn otel_span(tracer_provider: &SdkTracerProvider) -> (SpanContext, SpanContext) {
-            use opentelemetry::trace::TracerProvider;
-
-            tracer_provider
-                .tracer("otel_span")
-                .in_span("otel span", |_| {
-                    let outer = Context::current().span().span_context().clone();
-
-                    let inner = emit::Frame::push(SLOT.get().ctxt(), emit::Empty)
-                        .call(|| Context::current().span().span_context().clone());
-
-                    (outer, inner)
-                })
-        }
-
-        let (outer, inner) = otel_span(&tracer_provider);
-
-        assert_eq!(outer.trace_id(), inner.trace_id());
-        assert_eq!(outer.span_id(), inner.span_id());
-        assert_eq!(outer.trace_flags(), inner.trace_flags());
-    }
-
-    #[test]
     fn otel_span_emit_span() {
         static SLOT: AmbientSlot = AmbientSlot::new();
         let (_, spans, _, tracer_provider) = build(&SLOT);
 
-        fn otel_span(tracer_provider: &SdkTracerProvider) -> (SpanContext, emit::span::SpanCtxt) {
-            use opentelemetry::trace::TracerProvider;
-
-            #[emit::span(rt: SLOT.get(), "emit span")]
-            fn emit_span() -> emit::span::SpanCtxt {
-                emit::span::SpanCtxt::current(SLOT.get().ctxt())
-            }
-
-            tracer_provider
-                .tracer("otel_span")
-                .in_span("otel span", |cx| {
-                    (cx.span().span_context().clone(), emit_span())
-                })
-        }
-
-        let (otel_ctxt, emit_ctxt) = otel_span(&tracer_provider);
+        let ctxt = otel_span(&tracer_provider, |_| emit_span!(SLOT, |ctxt| ctxt));
 
         let spans = spans.get_finished_spans().unwrap();
 
         assert_eq!(2, spans.len());
 
-        assert_eq!(
-            otel_ctxt.trace_id().to_bytes(),
-            emit_ctxt.trace_id().unwrap().to_bytes()
-        );
-
         assert_eq!("emit span", spans[0].name);
 
         assert_eq!(
-            emit_ctxt.trace_id().unwrap().to_bytes(),
+            ctxt.trace_id().unwrap().to_bytes(),
             spans[0].span_context.trace_id().to_bytes()
         );
         assert_eq!(
-            emit_ctxt.span_id().unwrap().to_bytes(),
+            ctxt.span_id().unwrap().to_bytes(),
             spans[0].span_context.span_id().to_bytes()
         );
-        assert!(emit_ctxt.span_parent().is_none(),);
-        assert!(emit_ctxt.span_parent().is_none(),);
-
-        assert_eq!("otel span", spans[1].name);
-
         assert_eq!(
-            otel_ctxt.trace_id().to_bytes(),
-            spans[1].span_context.trace_id().to_bytes()
-        );
-        assert_eq!(
-            otel_ctxt.span_id().to_bytes(),
-            spans[1].span_context.span_id().to_bytes()
-        );
-        assert_eq!(SpanId::INVALID, spans[1].parent_span_id);
-    }
-
-    #[test]
-    fn otel_span_emit_log() {
-        static SLOT: AmbientSlot = AmbientSlot::new();
-        let (logs, _, _, tracer_provider) = build(&SLOT);
-
-        fn otel_span(tracer_provider: &SdkTracerProvider) -> SpanContext {
-            use opentelemetry::trace::TracerProvider;
-
-            tracer_provider
-                .tracer("otel_span")
-                .in_span("otel span", |cx| {
-                    emit::emit!(rt: SLOT.get(), "emit event");
-
-                    cx.span().span_context().clone()
-                })
-        }
-
-        let ctxt = otel_span(&tracer_provider);
-
-        let logs = logs.get_emitted_logs().unwrap();
-
-        assert_eq!(1, logs.len());
-
-        assert!(logs[0]
-            .record
-            .trace_context()
-            .unwrap()
-            .trace_flags
-            .unwrap()
-            .is_sampled());
-
-        assert_eq!(
-            ctxt.trace_id(),
-            logs[0].record.trace_context().unwrap().trace_id
-        );
-        assert_eq!(
-            ctxt.span_id(),
-            logs[0].record.trace_context().unwrap().span_id
+            ctxt.span_parent().unwrap().to_bytes(),
+            spans[0].parent_span_id.to_bytes()
         );
     }
 
     #[test]
     fn otel_span_unsampled_emit_span() {
         static SLOT: AmbientSlot = AmbientSlot::new();
-        let (logs, spans, _, tracer_provider) = build(&SLOT);
+        let (_, spans, _, tracer_provider) = build_with_sampler(&SLOT, Sampler::AlwaysOff);
 
-        #[emit::span(rt: SLOT.get(), "emit {attr}", attr: "span")]
-        fn emit_span() {
-            emit::emit!(rt: SLOT.get(), "emit event");
-        }
+        otel_span(&tracer_provider, |_| emit_span!(SLOT, |ctxt| ctxt));
 
-        fn otel_span(tracer_provider: &SdkTracerProvider) {
-            use opentelemetry::trace::TracerProvider;
-
-            let tracer = tracer_provider.tracer("otel_span");
-
-            let span = tracer
-                .span_builder("otel span")
-                .with_sampling_result(SamplingResult {
-                    decision: SamplingDecision::RecordOnly,
-                    attributes: Vec::new(),
-                    trace_state: TraceState::NONE,
-                });
-
-            let span = span.start(&tracer);
-            let cx = Context::current_with_span(span);
-            let _guard = cx.attach();
-
-            emit_span();
-        }
-
-        otel_span(&tracer_provider);
-
-        let logs = logs.get_emitted_logs().unwrap();
         let spans = spans.get_finished_spans().unwrap();
 
-        assert_eq!(1, logs.len());
         assert_eq!(0, spans.len());
-
-        assert!(!logs[0]
-            .record
-            .trace_context()
-            .unwrap()
-            .trace_flags
-            .unwrap()
-            .is_sampled());
     }
 
     #[test]
-    fn otel_span_unsampled_emit_log() {
+    fn emit_span() {
         static SLOT: AmbientSlot = AmbientSlot::new();
-        let (logs, _, _, tracer_provider) = build(&SLOT);
+        let (_, spans, _, tracer_provider) = build(&SLOT);
 
-        fn otel_span(tracer_provider: &SdkTracerProvider) -> SpanContext {
-            use opentelemetry::trace::TracerProvider;
+        // Spans outside sampled traces are ignored
+        let ctxt = emit_span!(SLOT, |ctxt| ctxt);
 
-            let tracer = tracer_provider.tracer("otel_span");
+        let spans = spans.get_finished_spans().unwrap();
 
-            let span = tracer.span_builder("otel span");
+        assert_eq!(0, spans.len());
 
-            let span = span
-                .with_sampling_result(SamplingResult {
-                    decision: SamplingDecision::Drop,
-                    attributes: vec![],
-                    trace_state: Default::default(),
-                })
-                .start(&tracer);
-            let cx = Context::current_with_span(span);
-            let _guard = cx.attach();
+        assert!(ctxt.trace_id().is_none());
+        assert!(ctxt.span_id().is_none());
+        assert!(ctxt.span_parent().is_none());
+    }
 
-            emit::emit!(rt: SLOT.get(), "emit event");
+    #[test]
+    fn otel_span_emit_span_direct() {
+        static SLOT: AmbientSlot = AmbientSlot::new();
+        let (_, spans, _, tracer_provider) = build(&SLOT);
 
-            Context::current().span().span_context().clone()
-        }
+        otel_span(&tracer_provider, |cx| {
+            // Direct span events are always ignored; we have no way to construct
+            // an otel span with the same span context
+            emit::emit!(rt: SLOT.get(), evt: emit::Span::new(
+                emit::mdl!(),
+                "emit span",
+                emit::Empty,
+                emit::props! {
+                    trace_id: emit_trace_id(cx.span().span_context().trace_id()),
+                    span_parent: emit_span_id(cx.span().span_context().span_id()),
+                    span_id: "00f067aa0ba902b7",
+                }
+            ));
+        });
 
-        let ctxt = otel_span(&tracer_provider);
+        let spans = spans.get_finished_spans().unwrap();
 
-        let logs = logs.get_emitted_logs().unwrap();
+        assert_eq!(1, spans.len());
+    }
 
-        assert_eq!(1, logs.len());
+    #[test]
+    fn otel_span_emit_span_name() {
+        todo!()
+    }
 
-        assert!(!logs[0]
-            .record
-            .trace_context()
-            .unwrap()
-            .trace_flags
-            .unwrap()
-            .is_sampled());
+    #[test]
+    fn otel_span_emit_span_kind() {
+        todo!()
+    }
 
-        assert_eq!(
-            ctxt.trace_id(),
-            logs[0].record.trace_context().unwrap().trace_id
-        );
-        assert_eq!(
-            ctxt.span_id(),
-            logs[0].record.trace_context().unwrap().span_id
-        );
+    #[test]
+    fn otel_span_emit_span_links() {
+        todo!()
+    }
+
+    #[test]
+    fn otel_span_emit_span_err() {
+        todo!()
     }
 
     #[test]


### PR DESCRIPTION
Closes #24 

This PR reworks the integration to work with the latest version of the OpenTelemetry SDK. We can no longer construct OTel spans with context reliably, so have tightened up support to hide any `emit` runtime infrastructure that would leak user-supplied trace context not being respected.

The main change here is that traces _only_ get emitted if you're already in the context of a sampled OTel trace. The trace needs to be constructed by the SDK first. This isn't likely to be a major issue in practice, because OTel already has a lot of sampling/propagation infrastructure that you're likely to be using.