### PR TITLE
Update to `emit` `2.x`

### DIFF
--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -32,3 +32,31 @@ jobs:
 
       - name: Minimal versions
         run: cargo hack test --feature-powerset --lib -Z minimal-versions
+
+  integration:
+    name: Test (Integration)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24.x
+
+      - name: Install Rust toolchain
+        run: rustup default nightly
+
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
+
+      - name: Get otelcol
+        run: wget -O otelcol.deb https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.107.0/otelcol_0.107.0_linux_amd64.deb
+
+      - name: Install otelcol
+        run: sudo dpkg -i ./otelcol.deb
+
+      - name: Integration Test
+        working-directory: ./emitter/otlp/test/integration
+        run: cargo hack run --feature-powerset

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -58,5 +58,5 @@ jobs:
         run: sudo dpkg -i ./otelcol.deb
 
       - name: Integration Test
-        working-directory: ./emitter/otlp/test/integration
+        working-directory: ./test/integration
         run: cargo hack run --feature-powerset

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,17 @@ members = [
 
 [features]
 default = ["implicit_rt"]
-implicit_rt = ["emit/implicit_rt"]
+implicit_rt = ["emit/implicit_rt", "emit1/implicit_rt"]
 
 [dependencies.emit]
-version = "1"
+version = "2"
 features = ["std", "serde", "implicit_internal_rt"]
+default-features = false
+
+[dependencies.emit1]
+version = "1"
+package = "emit"
+features = ["std"]
 default-features = false
 
 [dependencies.opentelemetry_sdk]
@@ -37,7 +43,7 @@ features = ["logs", "trace"]
 version = "1"
 
 [dev-dependencies.emit]
-version = "1.8"
+version = "2"
 features = ["implicit_rt"]
 
 [dev-dependencies.opentelemetry_sdk]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 members = [
     "examples/getting_started",
     "examples/multi_framework",
+    "test/integration",
 ]
 
 [features]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Configure the OpenTelemetry SDK as per its documentation, then add `emit` and `e
 
 ```toml
 [dependencies.emit]
-version = "1"
+version = "2"
 
 # add `emit_openetelemetry` with the same major/minor as the OpenTelemetry SDK
 [dependencies.emit_opentelemetry]

--- a/src/internal_metrics.rs
+++ b/src/internal_metrics.rs
@@ -23,11 +23,11 @@ macro_rules! metrics {
         }
 
         impl $internal_container {
-            pub fn sample(&self) -> impl Iterator<Item = emit::metric::Metric<'static, emit::empty::Empty>> + 'static {
+            pub fn sample1(&self) -> impl Iterator<Item = emit1::metric::Metric<'static, emit::empty::Empty>> + 'static {
                 let $internal_container { $($metric),* } = self;
 
                 [$(
-                    emit::metric::Metric::new(
+                    emit1::metric::Metric::new(
                         emit::pkg!(),
                         stringify!($metric),
                         <$ty>::AGG,
@@ -37,6 +37,24 @@ macro_rules! metrics {
                     ),
                 )*]
                 .into_iter()
+            }
+        }
+
+        impl emit::metric::Source for $internal_container {
+            fn sample_metrics<S: emit::metric::Sampler>(&self, sampler: S) {
+                let $internal_container { $($metric),* } = self;
+
+                $(
+                    sampler.metric(emit::metric::Metric::new(
+                        emit::pkg!(),
+                        emit::Empty,
+                        emit::props! {
+                            metric_name: stringify!($metric),
+                            metric_agg: <$ty>::AGG,
+                            metric_value: $metric.sample(),
+                        },
+                    ));
+                )*
             }
         }
 
@@ -100,10 +118,16 @@ pub struct EmitOpenTelemetryMetrics {
     pub(crate) metrics: Arc<InternalMetrics>,
 }
 
-impl emit::metric::Source for EmitOpenTelemetryMetrics {
-    fn sample_metrics<S: emit::metric::sampler::Sampler>(&self, sampler: S) {
-        for metric in self.metrics.sample() {
+impl emit1::metric::Source for EmitOpenTelemetryMetrics {
+    fn sample_metrics<S: emit1::metric::sampler::Sampler>(&self, sampler: S) {
+        for metric in self.metrics.sample1() {
             sampler.metric(metric);
         }
+    }
+}
+
+impl emit::metric::Source for EmitOpenTelemetryMetrics {
+    fn sample_metrics<S: emit::metric::Sampler>(&self, sampler: S) {
+        self.metrics.sample_metrics(sampler)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ Configure the OpenTelemetry SDK as per its documentation, then add `emit` and `e
 
 ```toml
 [dependencies.emit]
-version = "1"
+version = "2"
 
 # add `emit_opentelemetry` with the same major/minor as the OpenTelemetry SDK
 [dependencies.emit_opentelemetry]
@@ -236,7 +236,7 @@ where
     let metrics = Arc::new(InternalMetrics::default());
 
     Setup {
-        inner: emit::setup()
+        inner: emit1::setup()
             .with_clock(emit::Empty)
             .with_rng(emit::Empty)
             .emit_to(OpenTelemetryEmitter::new(
@@ -256,10 +256,10 @@ A partly initialized OpenTelemetry provider.
 */
 pub struct Setup<L, T> {
     metrics: Arc<InternalMetrics>,
-    inner: emit::Setup<
+    inner: emit1::Setup<
         OpenTelemetryEmitter<L>,
         OpenTelemetryIncomingFilter,
-        OpenTelemetryCtxt<emit::setup::DefaultCtxt, T>,
+        OpenTelemetryCtxt<emit1::setup::DefaultCtxt, T>,
         emit::Empty,
         emit::Empty,
     >,
@@ -334,7 +334,7 @@ where
     Initialize `emit`'s global runtime to forward to the OpenTelemetry SDK.
     */
     #[cfg(feature = "implicit_rt")]
-    pub fn init(self) -> emit::setup::Init<'static, impl emit::Emitter, impl emit::Ctxt> {
+    pub fn init(self) -> emit1::setup::Init<'static, impl emit::Emitter, impl emit::Ctxt> {
         self.inner.init()
     }
 
@@ -344,7 +344,7 @@ where
     #[cfg(feature = "implicit_rt")]
     pub fn try_init(
         self,
-    ) -> Option<emit::setup::Init<'static, impl emit::Emitter, impl emit::Ctxt>> {
+    ) -> Option<emit1::setup::Init<'static, impl emit::Emitter, impl emit::Ctxt>> {
         self.inner.try_init()
     }
 
@@ -354,7 +354,7 @@ where
     pub fn init_slot<'a>(
         self,
         slot: &'a AmbientSlot,
-    ) -> emit::setup::Init<'a, impl emit::Emitter, impl emit::Ctxt> {
+    ) -> emit1::setup::Init<'a, impl emit::Emitter, impl emit::Ctxt> {
         self.inner.init_slot(slot)
     }
 
@@ -364,7 +364,7 @@ where
     pub fn try_init_slot<'a>(
         self,
         slot: &'a AmbientSlot,
-    ) -> Option<emit::setup::Init<'a, impl emit::Emitter, impl emit::Ctxt>> {
+    ) -> Option<emit1::setup::Init<'a, impl emit::Emitter, impl emit::Ctxt>> {
         self.inner.try_init_slot(slot)
     }
 }
@@ -2207,9 +2207,9 @@ mod tests {
             // an otel span with the same span context
             emit::emit!(rt: SLOT.get(), evt: emit::Span::new(
                 emit::mdl!(),
-                "emit span",
                 emit::Empty,
                 emit::props! {
+                    span_name: "emit span",
                     trace_id: emit_trace_id(cx.span().span_context().trace_id()),
                     span_parent: emit_span_id(cx.span().span_context().span_id()),
                     span_id: "00f067aa0ba902b7",

--- a/test/integration/Cargo.toml
+++ b/test/integration/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "emit_oopentelemetry_test_integration"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[dependencies.emit]
+version = "2"
+
+[dependencies.emit_term]
+version = "2"
+
+[dependencies.emit_opentelemetry]
+path = "../../"
+
+[dependencies.opentelemetry_sdk]
+version = "0.32"
+features = ["rt-tokio", "trace", "logs"]
+
+[dependencies.opentelemetry]
+version = "0.32"
+features = ["trace", "logs"]
+
+[dependencies.opentelemetry-otlp]
+version = "0.32"
+features = ["trace", "logs", "grpc-tonic", "gzip-tonic"]
+
+[dependencies.tonic]
+version = "0.14"
+
+[dependencies.tokio]
+version = "1"
+features = ["rt", "macros", "rt-multi-thread"]
+
+[dependencies.uuid]
+version = "1"
+features = ["v4"]

--- a/test/integration/config.yaml
+++ b/test/integration/config.yaml
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "localhost:44319"
+
+exporters:
+  debug:
+    verbosity: detailed
+    sampling_initial: 1
+
+service:
+  telemetry:
+    metrics:
+      level: none
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [debug]
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]

--- a/test/integration/src/main.rs
+++ b/test/integration/src/main.rs
@@ -1,0 +1,118 @@
+/*!
+An integration test between `emit_opentelemetry` and the OpenTelemetry Collector.
+*/
+
+use std::{
+    io::Read,
+    process::{Child, Command, Stdio},
+    time::Duration,
+};
+
+use opentelemetry_otlp::WithTonicConfig as _;
+
+#[tokio::main]
+async fn main() {
+    let _ = emit::setup().emit_to(emit_term::stdout()).init_internal();
+
+    let otelcol = OtelCol::spawn("config");
+
+    // Configure the OpenTelemetry SDK
+    // In this example, we're configuring it to produce OTLP
+    let channel = tonic::transport::Channel::from_static("http://localhost:4319")
+        .connect()
+        .await
+        .unwrap();
+
+    let trace_exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .with_channel(channel.clone())
+        .build()
+        .unwrap();
+
+    let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_batch_exporter(trace_exporter)
+        .build();
+
+    let log_exporter = opentelemetry_otlp::LogExporter::builder()
+        .with_tonic()
+        .with_channel(channel.clone())
+        .build()
+        .unwrap();
+
+    let logger_provider = opentelemetry_sdk::logs::SdkLoggerProvider::builder()
+        .with_batch_exporter(log_exporter)
+        .build();
+
+    // Configure `emit` to point to `opentelemetry`
+    let _ = emit_opentelemetry::setup(logger_provider.clone(), tracer_provider.clone()).init();
+
+    // Generate some random ids
+    // These are used to assert the collector received our events
+    let log_uuid = uuid::Uuid::new_v4().to_string();
+    let span_uuid = uuid::Uuid::new_v4().to_string();
+
+    // Emit a log event
+    emit::info!("A log message {log_uuid}");
+
+    // Emit a span in a trace
+    #[emit::span(name: "emit_otlp_test", "A span {span_uuid}")]
+    async fn span(span_uuid: &str) {
+        tokio::time::sleep(Duration::from_millis(3)).await;
+    }
+    span(&span_uuid).await;
+
+    // Shutdown the SDK
+    let _ = logger_provider.shutdown();
+    let _ = tracer_provider.shutdown();
+
+    // Give the collector time to process events
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let output = otelcol.output();
+
+    // Ensure the collector received and accepted the events we emitted
+    assert_exporter(&output, "LogsExporter", &log_uuid);
+    assert_exporter(&output, "TracesExporter", &span_uuid);
+}
+
+fn assert_exporter(output: &str, exporter: &str, id: &str) {
+    assert!(
+        output.contains(&exporter),
+        "{exporter} not found in:\n{output}"
+    );
+    assert!(output.contains(id), "{id} not found in:\n{output}");
+}
+
+struct OtelCol(Child);
+
+impl Drop for OtelCol {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+    }
+}
+
+impl OtelCol {
+    fn spawn(config: &str) -> Self {
+        OtelCol(
+            Command::new("otelcol")
+                .args(["--config", &format!("./{config}.yaml")])
+                .stderr(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .unwrap(),
+        )
+    }
+
+    fn output(mut self) -> String {
+        let mut stdout = self.0.stdout.take().unwrap();
+        let mut stderr = self.0.stderr.take().unwrap();
+
+        self.0.kill().unwrap();
+
+        let mut buf = String::new();
+        stdout.read_to_string(&mut buf).unwrap();
+        stderr.read_to_string(&mut buf).unwrap();
+
+        buf
+    }
+}

--- a/test/integration/src/main.rs
+++ b/test/integration/src/main.rs
@@ -5,6 +5,7 @@ An integration test between `emit_opentelemetry` and the OpenTelemetry Collector
 use std::{
     io::Read,
     process::{Child, Command, Stdio},
+    thread,
     time::Duration,
 };
 
@@ -17,7 +18,7 @@ async fn main() {
     let otelcol = OtelCol::spawn("config");
 
     // Give the collector time to stand up
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     // Configure the OpenTelemetry SDK
     // In this example, we're configuring it to produce OTLP
@@ -47,42 +48,60 @@ async fn main() {
         .build();
 
     // Configure `emit` to point to `opentelemetry`
-    let _ = emit_opentelemetry::setup(logger_provider.clone(), tracer_provider.clone()).init();
+    let setup = emit_opentelemetry::setup(logger_provider.clone(), tracer_provider.clone());
+    let metrics = setup.metric_source();
+    let _ = setup.init();
 
     // Generate some random ids
     // These are used to assert the collector received our events
     let log_uuid = uuid::Uuid::new_v4().to_string();
     let span_uuid = uuid::Uuid::new_v4().to_string();
 
-    // Emit a log event
-    emit::info!("A log message {log_uuid}");
+    run_opentelemetry(tracer_provider.clone(), || {
+        // Emit a log event
+        emit::info!("A log message {log_uuid}");
 
-    // Emit a span in a trace
-    #[emit::span(name: "emit_otlp_test", "A span {span_uuid}")]
-    async fn span(span_uuid: &str) {
-        tokio::time::sleep(Duration::from_millis(3)).await;
-    }
-    span(&span_uuid).await;
+        // Emit a span in a trace
+        #[emit::span(name: "emit_opentelemetry_test", "A span {span_uuid}")]
+        fn span(span_uuid: &str) {
+            thread::sleep(Duration::from_secs(1));
+        }
+        span(&span_uuid);
+    });
 
     // Shutdown the SDK
     let _ = logger_provider.shutdown();
     let _ = tracer_provider.shutdown();
 
     // Give the collector time to process events
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    emit::metric::Source::sample_metrics(
+        &metrics,
+        emit::metric::sampler::from_emitter(emit::runtime::internal()),
+    );
 
     let output = otelcol.output();
 
     // Ensure the collector received and accepted the events we emitted
-    assert_exporter(&output, "LogsExporter", &log_uuid);
-    assert_exporter(&output, "TracesExporter", &span_uuid);
+    assert_exporter(&output, &log_uuid);
+    assert_exporter(&output, &span_uuid);
 }
 
-fn assert_exporter(output: &str, exporter: &str, id: &str) {
-    assert!(
-        output.contains(&exporter),
-        "{exporter} not found in:\n{output}"
-    );
+fn run_opentelemetry<T: opentelemetry::trace::TracerProvider>(tracer_provider: T, f: impl FnOnce())
+where
+    <T::Tracer as opentelemetry::trace::Tracer>::Span: Send + Sync + 'static,
+{
+    use opentelemetry::trace::Tracer;
+
+    tracer_provider
+        .tracer("run_opentelemetry")
+        .in_span("Running OTel", |_| {
+            f();
+        })
+}
+
+fn assert_exporter(output: &str, id: &str) {
     assert!(output.contains(id), "{id} not found in:\n{output}");
 }
 

--- a/test/integration/src/main.rs
+++ b/test/integration/src/main.rs
@@ -16,9 +16,12 @@ async fn main() {
 
     let otelcol = OtelCol::spawn("config");
 
+    // Give the collector time to stand up
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
     // Configure the OpenTelemetry SDK
     // In this example, we're configuring it to produce OTLP
-    let channel = tonic::transport::Channel::from_static("http://localhost:4319")
+    let channel = tonic::transport::Channel::from_static("http://localhost:44319")
         .connect()
         .await
         .unwrap();


### PR DESCRIPTION
This PR updates the OpenTelemetry integration to `emit` `2.x`. I've kept the version compatible with `1.x` to avoid needing to perform a minor version bump. That keeps it in sync with the upstream `opentelemetry` crate versioning.